### PR TITLE
Ra dspdc 982 refactor hles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .scalafmt.conf
+.idea

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -86,7 +86,7 @@ class HLESurveyExtractionPipelineBuilder(
       .parallelize(Iterable(()))
       .transform("Get study IDs") {
         _.applyKvTransform(ParDo.of(idLookupFn)).flatMap { kv =>
-          kv.getValue.fold(throw _, _.arr.map(_.read[String]("study_id")))
+          kv.getValue.fold(throw _, _.arr.map(_.read[String]("value")))
         }
       }
 

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -30,6 +30,8 @@ object HLESurveyExtractionPipelineBuilder {
     "meds_and_preventives",
     "health_status"
   )
+
+  val MaxConcurrentRequests = 8
 }
 
 /**
@@ -61,6 +63,7 @@ class HLESurveyExtractionPipelineBuilder(
 
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     import org.broadinstitute.monster.common.msg.MsgOps
+    import HLESurveyExtractionPipelineBuilder._
 
     val idLookupFn = new ScalaAsyncLookupDoFn[Unit, Msg, RedCapClient]() {
       override def newClient(): RedCapClient = getClient()
@@ -96,18 +99,19 @@ class HLESurveyExtractionPipelineBuilder(
       .applyKvTransform(GroupIntoBatches.ofSize(idBatchSize.toLong))
       .map(_.getValue.asScala)
 
-    val formLookupFn = new ScalaAsyncLookupDoFn[Iterable[String], Msg, RedCapClient]() {
-      override def newClient(): RedCapClient = getClient()
-      override def asyncLookup(
-        client: RedCapClient,
-        input: Iterable[String]
-      ): Future[Msg] =
-        client.getRecords(
-          args.apiToken,
-          ids = input.toList,
-          forms = HLESurveyExtractionPipelineBuilder.ExtractedForms
-        )
-    }
+    val formLookupFn =
+      new ScalaAsyncLookupDoFn[Iterable[String], Msg, RedCapClient](MaxConcurrentRequests) {
+        override def newClient(): RedCapClient = getClient()
+        override def asyncLookup(
+          client: RedCapClient,
+          input: Iterable[String]
+        ): Future[Msg] =
+          client.getRecords(
+            args.apiToken,
+            ids = input.toList,
+            forms = ExtractedForms
+          )
+      }
 
     // Download the form data for each batch of records.
     val extractedRecords = batchedIds.transform("Get HLE records") {

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -83,9 +83,9 @@ object RedCapClient {
         .add("content", "record")
         .add("format", "json")
         .add("returnFormat", "json")
-        .add("type", "flat")
+        .add("type", "eav")
         // Get labeled answers so we can pass through data when possible.
-        .add("rawOrLabel", "label")
+        .add("rawOrLabel", "raw")
         // Keep field keys as raw strings, to make programmatic manipulation easier.
         .add("rawOrLabelHeaders", "raw")
         .add("exportCheckboxLabel", "false")

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -84,7 +84,7 @@ object RedCapClient {
         .add("format", "json")
         .add("returnFormat", "json")
         .add("type", "eav")
-        // Get labeled answers so we can pass through data when possible.
+        // Get raw answers so we can pass through data when possible.
         .add("rawOrLabel", "raw")
         // Keep field keys as raw strings, to make programmatic manipulation easier.
         .add("rawOrLabelHeaders", "raw")

--- a/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
+++ b/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
@@ -33,7 +33,7 @@ object HLESurveyExtractionPipelineBuilderSpec {
 
   val expectedOut = fakeIds.map { i =>
     Obj(
-      Str("study_id") -> Str(i.toString),
+      Str("value") -> Str(i.toString),
       Str("some_attribute") -> Str(s"This is the ${i}th attribute"),
       Str("excitement_level") -> Str("a" * i + "!")
     )
@@ -44,7 +44,7 @@ object HLESurveyExtractionPipelineBuilderSpec {
     downloadQueries.zip(expectedOut.map(Arr(_))).toMap + (
       initQuery -> new Arr(
         fakeIds
-          .map(i => Obj(Str("study_id") -> Str(i.toString)): Msg)
+          .map(i => Obj(Str("value") -> Str(i.toString)): Msg)
           .to[mutable.ArrayBuffer]
       )
     )


### PR DESCRIPTION
Export raw values instead of labels, export in "eav" mode instead of "flat" mode, establish a global concurrency limit like in ENCODE.