### PR TITLE
Ra dspdc 983 extract data dictionaries

### DIFF
--- a/hle-survey/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hle-survey/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderIntegrationSpec.scala
@@ -48,7 +48,11 @@ class HLESurveyExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderS
 
   behavior of "HLESurveyExtractionPipelineBuilder"
 
-  it should "successfully download some stuff from RedCap" in {
-    readMsgs(outputDir) shouldNot be(empty)
+  it should "successfully download records from RedCap" in {
+    readMsgs(outputDir, "records/*.json") shouldNot be(empty)
+  }
+
+  it should "successfully download data dictionaries from RedCap" in {
+    readMsgs(outputDir, "data_dictionaries/*.json") shouldNot be(empty)
   }
 }

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -73,10 +73,12 @@ class HLESurveyExtractionPipelineBuilder(
       ): Future[Msg] =
         client.getRecords(
           args.apiToken,
-          fields = List("study_id"),
-          start = args.startTime,
-          end = args.endTime,
-          valueFilters = Map("co_consent" -> "1")
+          request = GetRecords(
+            fields = List("study_id"),
+            start = args.startTime,
+            end = args.endTime,
+            filters = Map("co_consent" -> "1")
+          )
         )
     }
 
@@ -108,8 +110,7 @@ class HLESurveyExtractionPipelineBuilder(
         ): Future[Msg] =
           client.getRecords(
             args.apiToken,
-            ids = input.toList,
-            forms = ExtractedForms
+            request = GetRecords(ids = input.toList, forms = ExtractedForms)
           )
       }
 
@@ -118,11 +119,19 @@ class HLESurveyExtractionPipelineBuilder(
       _.applyKvTransform(ParDo.of(formLookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
     }
 
+    // Download the data dictionary for every form.
+//    val extractedDataDictionaries = ???
+
     StorageIO.writeJsonLists(
       extractedRecords,
       "HLE Records",
       args.outputPrefix
     )
+//    StorageIO.writeJsonLists(
+//      extractedDataDictionaries,
+//      "HLE Data Dictionaries",
+//      args.outputPrefix
+//    )
     ()
   }
 }

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -71,9 +71,9 @@ class HLESurveyExtractionPipelineBuilder(
         client: RedCapClient,
         input: Unit
       ): Future[Msg] =
-        client.getRecords(
+        client.get(
           args.apiToken,
-          request = GetRecords(
+          GetRecords(
             fields = List("study_id"),
             start = args.startTime,
             end = args.endTime,
@@ -99,39 +99,41 @@ class HLESurveyExtractionPipelineBuilder(
       .map(KV.of("", _))
       .setCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
       .applyKvTransform(GroupIntoBatches.ofSize(idBatchSize.toLong))
-      .map(_.getValue.asScala)
+      .map(ids => GetRecords(ids = ids.getValue.asScala.toList, forms = ExtractedForms))
 
-    val formLookupFn =
-      new ScalaAsyncLookupDoFn[Iterable[String], Msg, RedCapClient](MaxConcurrentRequests) {
+    val lookupFn =
+      new ScalaAsyncLookupDoFn[RedcapRequest, Msg, RedCapClient](MaxConcurrentRequests) {
         override def newClient(): RedCapClient = getClient()
         override def asyncLookup(
           client: RedCapClient,
-          input: Iterable[String]
+          input: RedcapRequest
         ): Future[Msg] =
-          client.getRecords(
-            args.apiToken,
-            request = GetRecords(ids = input.toList, forms = ExtractedForms)
-          )
+          client.get(args.apiToken, input)
       }
 
     // Download the form data for each batch of records.
     val extractedRecords = batchedIds.transform("Get HLE records") {
-      _.applyKvTransform(ParDo.of(formLookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
+      _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
     }
 
     // Download the data dictionary for every form.
-//    val extractedDataDictionaries = ???
+    val extractedDataDictionaries = ctx
+      .parallelize(ExtractedForms)
+      .map(instrument => GetDataDictionary(instrument))
+      .transform("Get data dictionary") {
+        _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
+      }
 
     StorageIO.writeJsonLists(
       extractedRecords,
       "HLE Records",
-      args.outputPrefix
+      s"${args.outputPrefix}/records"
     )
-//    StorageIO.writeJsonLists(
-//      extractedDataDictionaries,
-//      "HLE Data Dictionaries",
-//      args.outputPrefix
-//    )
+    StorageIO.writeJsonLists(
+      extractedDataDictionaries,
+      "HLE Data Dictionaries",
+      s"${args.outputPrefix}/data_dictionaries"
+    )
     ()
   }
 }

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -23,7 +23,7 @@ trait RedCapClient extends Serializable {
     * @param apiToken auth token to use when querying the API
     * @param request ADT capturing the various parameters for a request to a particular endpoint
     */
-  def getRecords(
+  def get(
     apiToken: String,
     request: RedcapRequest
   ): Future[Msg]
@@ -60,7 +60,7 @@ object RedCapClient {
             s"end: [$end]",
             s"filters: [${filters.map { case (k, v) => s"$k=$v" }.mkString(",")}]"
           )
-          logger.debug(s"Querying RedCap: ${logPieces.mkString(",")}")
+          logger.debug(s"Querying RedCap for records: ${logPieces.mkString(",")}")
 
           val formBuilder = new FormBody.Builder()
             .add("token", apiToken)
@@ -96,6 +96,11 @@ object RedCapClient {
           }
           formBuilder
         case GetDataDictionary(instrument) =>
+          val logPieces = List(
+            s"forms: [${instrument}]"
+          )
+          logger.debug(s"Querying RedCap for data dictionary: ${logPieces.mkString(",")}")
+
           new FormBody.Builder()
             .add("token", apiToken)
             // Export individual survey records as JSON.

--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedcapRequest.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/RedcapRequest.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.monster.dap
+
+import java.time.OffsetDateTime
+
+sealed trait RedcapRequest
+
+/**
+  * NOTE: Record-level filters are combined with AND-ing logic. Field-level
+  * filters are combined with OR-ing logic. For hitting the records endpoint.
+  *
+  * @param ids IDs of the specific records to download. If not set, all
+  *            records will be downloaded
+  *
+  * @param fields  subset of fields to download. If not set, all fields
+  *                will be downloaded
+  * @param forms   subset of forms to download. If not set, fields from all
+  *                forms will be downloaded
+  * @param start   if given, only records created-or-updated at or after this
+  *                time will be downloaded
+  * @param end     if given, only records created-or-updated before or at this
+  *                time will be downloaded
+  * @param filters arbitrary field-value pairs to use as an exact-match
+  *                filter on downloaded records
+  **/
+case class GetRecords(
+  ids: List[String] = Nil,
+  fields: List[String] = Nil,
+  forms: List[String] = Nil,
+  start: Option[OffsetDateTime] = None,
+  end: Option[OffsetDateTime] = None,
+  filters: Map[String, String] = Map.empty
+) extends RedcapRequest
+
+/**
+  * For hitting the data dictionary / metadata endpoint.
+  *
+  * @param instrument name specifying specific data collection instrument
+  *                   for which you wish to pull metadata
+  */
+case class GetDataDictionary(instrument: String) extends RedcapRequest

--- a/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
+++ b/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
@@ -9,7 +9,6 @@ import upack._
 import scala.collection.mutable
 
 object HLESurveyExtractionPipelineBuilderSpec {
-  import MockRedCapClient.QueryParams
 
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()
@@ -17,18 +16,18 @@ object HLESurveyExtractionPipelineBuilderSpec {
 
   val fakeIds = 1 to 50
 
-  val initQuery = QueryParams(
+  val initQuery = GetRecords(
     start = Some(start),
     end = Some(end),
     fields = List("study_id"),
     filters = Map("co_consent" -> "1")
-  )
+  ): RedcapRequest
 
   val downloadQueries = fakeIds.map { i =>
-    QueryParams(
+    GetRecords(
       ids = List(i.toString),
       forms = HLESurveyExtractionPipelineBuilder.ExtractedForms
-    )
+    ): RedcapRequest
   }
 
   val expectedOut = fakeIds.map { i =>

--- a/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/MockRedCapClient.scala
+++ b/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/MockRedCapClient.scala
@@ -12,7 +12,7 @@ class MockRedCapClient(
 ) extends RedCapClient {
   val recordedRequests = mutable.Set[RedcapRequest]()
 
-  override def getRecords(
+  override def get(
     apiToken: String,
     request: RedcapRequest
   ): Future[Msg] = {


### PR DESCRIPTION
Added data dictionaries to the HLES extraction pipeline, which also included a handful of changes like adding an ADT and using one lookupFn instance after the first id querying one. This involved a bunch of updates to the RedCapClient, the mock client, unit tests, and integration tests as well. Obviously check the logic/code quality, but I'm also concerned with word choice (wasn't sure if I should be saying "dictionary" or "dictionaries"), and whether or not "data_dictionaries" is a good file path to write to.