### PR TITLE
Ra dspdc 984 additional studies

### DIFF
--- a/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hle-survey/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -28,7 +28,8 @@ object HLESurveyExtractionPipelineBuilder {
     "behavior",
     "diet",
     "meds_and_preventives",
-    "health_status"
+    "health_status",
+    "additional_studies"
   )
 
   val MaxConcurrentRequests = 8

--- a/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
+++ b/hle-survey/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilderSpec.scala
@@ -15,7 +15,7 @@ object HLESurveyExtractionPipelineBuilderSpec {
   val start = OffsetDateTime.now()
   val end = start.plusDays(3).plusHours(10).minusSeconds(100)
 
-  val fakeIds = 1 to 7
+  val fakeIds = 1 to 50
 
   val initQuery = GetRecords(
     start = Some(start),


### PR DESCRIPTION
add "additional_studies" to the list of forms to use in the extraction pipeline. All tests still pass, sooo pretty darn small diff.