### PR TITLE
QH - DSPDC-1028 - Bumping sbtPluginsVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import org.broadinstitute.monster.sbt.model.JadeIdentifier
-
 val okhttpVersion = "4.4.1"
 val vaultDriverVersion = "5.1.0"
 
@@ -12,10 +10,6 @@ lazy val `dog-aging-schema` = project
   .in(file("schema"))
   .enablePlugins(MonsterJadeDatasetPlugin)
   .settings(
-    jadeDatasetName := JadeIdentifier
-      .fromString("broad_dsp_dog_aging")
-      .fold(sys.error, identity),
-    jadeDatasetDescription := "Mirror of the Dog Aging Project, maintained by Broad's Data Sciences Platform",
     jadeTablePackage := "org.broadinstitute.monster.dogaging.jadeschema.table",
     jadeStructPackage := "org.broadinstitute.monster.dogaging.jadeschema.struct"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-val pluginsVersion = "0.20.0"
+val sbtPluginsVersion = "0.23.0"
 
-addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-jade" % pluginsVersion)
-addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-scio" % pluginsVersion)
+addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-jade" % sbtPluginsVersion)
+addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-scio" % sbtPluginsVersion)


### PR DESCRIPTION
Updating the sbtPluginsVersion to match the most recent monster-sbt-plugins release.
Updating build.sbt to reflect Raaid's downstream changes in DSPDC-1067.
Updating the variable name to match the name used in other projects: "sbtPluginsVersion" instead of "pluginsVersion".
Pipeline tests completed successfully.