### PR TITLE
Sw dspdc 1063 transform st columns

### DIFF
--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -31,7 +31,8 @@ object DogTransformations {
   }
 
   /**
-    *
+    * Parse all study-status-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
     */
   def mapStudyStatus(rawRecord: RawRecord, dog: HlesDog): HlesDog =
     dog.copy(

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -9,73 +9,10 @@ object DogTransformations {
 
   /** Parse all dog-related fields out of a raw RedCap record. */
   def mapDog(rawRecord: RawRecord): HlesDog = {
-    val dogBase = HlesDog(
+    val dogBase = HlesDog.init(
       dogId = rawRecord.id,
       // FIXME: Once DAP figures out a name for a dedicated owner ID, use that.
-      ownerId = rawRecord.id,
-      // withBreed
-      ddBreedPure = None,
-      ddBreedPureNonAkc = None,
-      ddBreedMixedPrimary = None,
-      ddBreedMixedSecondary = None,
-      // withAge
-      ddAgeYears = None,
-      ddAgeBasis = None,
-      ddAgeExactSource = Array.empty,
-      ddAgeExactSourceOther = None,
-      ddAgeEstimateSource = Array.empty,
-      ddAgeEstimateSourceOther = None,
-      ddBirthYear = None,
-      ddBirthMonth = None,
-      // withSex
-      ddSex = None,
-      // withSpayNeuter
-      ddSpayedOrNeutered = None,
-      ddSpayOrNeuterAge = None,
-      ddSpayMethod = None,
-      ddEstrousCycleExperiencedBeforeSpayed = None,
-      ddEstrousCycleCount = None,
-      ddHasBeenPregnant = None,
-      ddHasSiredLitters = None,
-      ddLitterCount = None,
-      // withWeight
-      ddWeightRange = None,
-      ddWeightLbs = None,
-      ddWeightRangeExpectedAdult = None,
-      // withInsurance
-      ddInsuranceProvider = None,
-      ddInsuranceProviderOther = None,
-      // withAcquired
-      ddAcquiredYear = None,
-      ddAcquiredMonth = None,
-      ddAcquiredSource = None,
-      ddAcquiredSourceOther = None,
-      ddAcquiredCountry = None,
-      ddAcquiredState = None,
-      ddAcquiredZip = None,
-      // withRoles
-      ddPrimaryRole = None,
-      ddPrimaryRoleOther = None,
-      ddSecondaryRole = None,
-      ddSecondaryRoleOther = None,
-      ddOtherRoles = Array.empty,
-      ddServiceTypes = Array.empty,
-      ddServiceTypesOtherMedical = None,
-      ddServiceTypesOtherHealth = None,
-      ddServiceTypesOther = None,
-      // withResidences
-      ocPrimaryResidenceState = None,
-      ocPrimaryResidenceCensusDivision = None,
-      ocPrimaryResidenceZip = None,
-      ocPrimaryResidenceOwnership = None,
-      ocPrimaryResidenceOwnershipOther = None,
-      ocPrimaryResidenceTimePercentage = None,
-      ocSecondaryResidenceState = None,
-      ocSecondaryResidenceZip = None,
-      ocSecondaryResidenceOwnership = None,
-      ocSecondaryResidenceOwnershipOther = None,
-      ocSecondaryResidenceTimePercentage = None,
-      ddOtherRecentShortTermResidences = Array.empty
+      ownerId = rawRecord.id
     )
 
     val transformations = List(
@@ -90,6 +27,19 @@ object DogTransformations {
     )
 
     transformations.foldLeft(dogBase)((acc, f) => f(rawRecord, acc))
+  }
+
+  /**
+    *
+    */
+  def mapStudyStatus(rawRecord: RawRecord, dog: HlesDog): HlesDog = {
+    dog.copy(
+      stVipOrStaff = rawRecord.getOptional("st_vip_or_staff"),
+      stBatchLabel = rawRecord.getOptional("st_batch_label"),
+      stPortalInvitationDate = "st_invite_to_portal",
+      stPortalAccountCreationDate = "st_portal_account_date",
+      stHlesCompletionDate = "st_dap_pack_date"
+    )
   }
 
   /**

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -36,7 +36,7 @@ object DogTransformations {
     */
   def mapStudyStatus(rawRecord: RawRecord, dog: HlesDog): HlesDog =
     dog.copy(
-      stVipOrStaff = rawRecord.getOptional("st_vip_or_staff"),
+      stVipOrStaff = rawRecord.getOptionalNumber("st_vip_or_staff"),
       stBatchLabel = rawRecord.getOptional("st_batch_label"),
       stPortalInvitationDate = rawRecord.getOptionalDate("st_invite_to_portal"),
       stPortalAccountCreationDate = rawRecord.getOptionalDate("st_portal_account_date"),

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -16,6 +16,7 @@ object DogTransformations {
     )
 
     val transformations = List(
+      mapStudyStatus _,
       mapBreed _,
       mapAge _,
       mapSexSpayNeuter _,
@@ -32,15 +33,14 @@ object DogTransformations {
   /**
     *
     */
-  def mapStudyStatus(rawRecord: RawRecord, dog: HlesDog): HlesDog = {
+  def mapStudyStatus(rawRecord: RawRecord, dog: HlesDog): HlesDog =
     dog.copy(
       stVipOrStaff = rawRecord.getOptional("st_vip_or_staff"),
       stBatchLabel = rawRecord.getOptional("st_batch_label"),
-      stPortalInvitationDate = "st_invite_to_portal",
-      stPortalAccountCreationDate = "st_portal_account_date",
-      stHlesCompletionDate = "st_dap_pack_date"
+      stPortalInvitationDate = rawRecord.getOptionalDate("st_invite_to_portal"),
+      stPortalAccountCreationDate = rawRecord.getOptionalDate("st_portal_account_date"),
+      stHlesCompletionDate = rawRecord.getOptionalDate("st_dap_pack_date")
     )
-  }
 
   /**
     * Parse all breed-related fields out of a raw RedCap record,

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.monster.dap
 
+import java.time.LocalDate
+
 /**
   * Container for the raw properties pulled from RedCap for a single dog.
   *
@@ -42,6 +44,10 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
 
   /** Get the singleton value for an attribute in this record if one exists, parsed as a boolean. */
   def getOptionalBoolean(field: String): Option[Boolean] = getOptional(field).map(_ == "1")
+
+  /** Get the singleton value for an attribute in this record if one exists, parsed as a date. */
+  def getOptionalDate(field: String): Option[LocalDate] =
+    getOptional(field).map(LocalDate.parse(_, DateTimeFormatter.ofPattern("MM-dd-yyyy")))
 
   /** Get every value for an attribute in this record. */
   def getArray(field: String): Array[String] = fields.getOrElse(field, Array.empty)

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.monster.dap
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 /**
   * Container for the raw properties pulled from RedCap for a single dog.

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -46,6 +46,9 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   /** Get the singleton value for an attribute in this record if one exists, parsed as a boolean. */
   def getOptionalBoolean(field: String): Option[Boolean] = getOptional(field).map(_ == "1")
 
+  /** Get the singleton value for an attribute in this record, parsed as a long. */
+  def getOptionalNumber(field: String): Option[Long] = getOptional(field).map(_.toLong)
+
   /** Get the singleton value for an attribute in this record if one exists, parsed as a date. */
   def getOptionalDate(field: String): Option[LocalDate] =
     getOptional(field).map(LocalDate.parse(_, DateTimeFormatter.ofPattern("MM-dd-yyyy")))

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.monster.dap
 
+import org.broadinstitute.monster.dogaging.jadeschema.table.HlesDog
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import java.time.LocalDate
@@ -11,16 +12,18 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers {
 
   it should "correctly map study status fields" in {
     val exampleDogFields = Map[String, Array[String]](
-      "dd_us_born" -> Array("1"), // a required field
       "st_vip_or_staff" -> Array("2"),
       "st_batch_label" -> Array("this is my label"),
       "st_invite_to_portal" -> Array("05-22-2020"),
       "st_portal_account_date" -> Array("01-01-2000"),
       "st_dap_pack_date" -> Array("12-31-1999")
     )
-    val output = DogTransformations.mapDog(RawRecord(id = 1, exampleDogFields))
+    val output = DogTransformations.mapStudyStatus(
+      RawRecord(id = 1, exampleDogFields),
+      HlesDog.init(dogId = 1, ownerId = 1)
+    )
 
-    output.stVipOrStaff shouldBe Some("2")
+    output.stVipOrStaff shouldBe Some(2)
     output.stBatchLabel shouldBe Some("this is my label")
     output.stPortalInvitationDate shouldBe Some(LocalDate.of(2020, 5, 22))
     output.stPortalAccountCreationDate shouldBe Some(LocalDate.of(2000, 1, 1))

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import java.time.LocalDate
 
 class DogTransformationsSpec extends AnyFlatSpec with Matchers {
   behavior of "DogTransformations"
@@ -10,20 +11,21 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers {
 
   it should "correctly map study status fields" in {
     val exampleDogFields = Map[String, Array[String]](
-      "st_vip_or_staff" -> Array("2"), // multiple choice
+      "dd_us_born" -> Array("1"),
+      "st_vip_or_staff" -> Array("2"),
       "st_batch_label" -> Array("this is my label"),
-      "st_portal_invitation_date" -> Array("05-22-2020"),
-      "st_portal_account_creation_date" -> Array("01-01-2000"),
-      "st_hles_completion_date" -> Array("12-31-1999")
+      "st_invite_to_portal" -> Array("05-22-2020"),
+      "st_portal_account_date" -> Array("01-01-2000"),
+      "st_dap_pack_date" -> Array("12-31-1999")
     )
     val exampleDogRecord =
       RawRecord(id = 1, exampleDogFields)
     val output = DogTransformations.mapDog(exampleDogRecord)
 
-    output.stVipOrStaff shouldBe None
-    output.stBatchLabel shouldBe None
-    output.stPortalInvitationDate shouldBe None
-    output.stPortalAccountCreationDate shouldBe None
-    output.stHlesCompletionDate shouldBe None
+    output.stVipOrStaff shouldBe Some("2")
+    output.stBatchLabel shouldBe Some("this is my label")
+    output.stPortalInvitationDate shouldBe Some(LocalDate.of(2020, 5, 22))
+    output.stPortalAccountCreationDate shouldBe Some(LocalDate.of(2000, 1, 1))
+    output.stHlesCompletionDate shouldBe Some(LocalDate.of(1999, 12, 31))
   }
 }

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.monster.dap
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DogTransformationsSpec extends AnyFlatSpec with Matchers {
+  behavior of "DogTransformations"
+
+  // TODO add tests for dog demographics transformation
+
+  it should "correctly map study status fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "st_vip_or_staff" -> Array("2"), // multiple choice
+      "st_batch_label" -> Array("this is my label"),
+      "st_portal_invitation_date" -> Array("05-22-2020"),
+      "st_portal_account_creation_date" -> Array("01-01-2000"),
+      "st_hles_completion_date" -> Array("12-31-1999")
+    )
+    val exampleDogRecord =
+      RawRecord(id = 1, exampleDogFields)
+    val output = DogTransformations.mapDog(exampleDogRecord)
+
+    output.stVipOrStaff shouldBe None
+    output.stBatchLabel shouldBe None
+    output.stPortalInvitationDate shouldBe None
+    output.stPortalAccountCreationDate shouldBe None
+    output.stHlesCompletionDate shouldBe None
+  }
+}

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -11,16 +11,14 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers {
 
   it should "correctly map study status fields" in {
     val exampleDogFields = Map[String, Array[String]](
-      "dd_us_born" -> Array("1"),
+      "dd_us_born" -> Array("1"), // a required field
       "st_vip_or_staff" -> Array("2"),
       "st_batch_label" -> Array("this is my label"),
       "st_invite_to_portal" -> Array("05-22-2020"),
       "st_portal_account_date" -> Array("01-01-2000"),
       "st_dap_pack_date" -> Array("12-31-1999")
     )
-    val exampleDogRecord =
-      RawRecord(id = 1, exampleDogFields)
-    val output = DogTransformations.mapDog(exampleDogRecord)
+    val output = DogTransformations.mapDog(RawRecord(id = 1, exampleDogFields))
 
     output.stVipOrStaff shouldBe Some("2")
     output.stBatchLabel shouldBe Some("this is my label")

--- a/schema/src/main/jade-tables/hles_dog.table.json
+++ b/schema/src/main/jade-tables/hles_dog.table.json
@@ -18,6 +18,26 @@
       ]
     },
     {
+      "name": "st_vip_or_staff",
+      "datatype": "string"
+    },
+    {
+      "name": "st_batch_label",
+      "datatype": "string"
+    },
+    {
+      "name": "st_portal_invitation_date",
+      "datatype": "date"
+    },
+    {
+      "name": "st_portal_account_creation_date",
+      "datatype": "date"
+    },
+    {
+      "name": "st_hles_completion_date",
+      "datatype": "date"
+    },
+    {
       "name": "dd_breed_pure",
       "datatype": "string"
     },

--- a/schema/src/main/jade-tables/hles_dog.table.json
+++ b/schema/src/main/jade-tables/hles_dog.table.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "st_vip_or_staff",
-      "datatype": "string"
+      "datatype": "integer"
     },
     {
       "name": "st_batch_label",


### PR DESCRIPTION
Adding the study status columns to the dog aging transformation (just 5 columns). I was using this as an excuse to also:
- get rid of the massive HlesDog constructor, and use the new init method instead
- set up a test class for the dog transformations

@danxmoran (after the weekend) let me know if there is something else you had in mind for how to test these transformations. I would be happy to change, especially if something else would be easier in the long run. 