### PR TITLE
Debug changes to hospitalization reason fields

### DIFF
--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
@@ -25,8 +25,8 @@ object HealthStatusTransformations {
     */
   def mapHealthSummary(rawRecord: RawRecord, dog: HlesDog): HlesDog = {
     val recentHospitalization = rawRecord.getOptionalBoolean("hs_hosp_yn")
-    val hospitalizationReason = recentHospitalization.flatMap {
-      if (_) rawRecord.getOptionalNumber("hs_hosp_why") else None
+    val hospitalizationReasons = recentHospitalization.flatMap {
+      if (_) rawRecord.get("hs_hosp_why") else None
     }
 
     dog.copy(
@@ -39,12 +39,16 @@ object HealthStatusTransformations {
         rawRecord.getOptionalBoolean("hs_cond_chron_change"),
       hsCongenitalConditionPresent = rawRecord.getOptionalBoolean("hs_congenital_yn"),
       hsRecentHospitalization = recentHospitalization,
-      hsRecentHospitalizationReason = hospitalizationReason,
-      hsRecentHospitalizationReasonOtherDescription = if (hospitalizationReason.contains(98L)) {
-        rawRecord.getOptional("hs_hosp_why_other")
-      } else {
-        None
-      },
+      hsRecentHospitalizationReasonSpayOrNeuter = hospitalizationReasons.map(_.contains("1")),
+      hsRecentHospitalizationReasonDentistry = hospitalizationReasons.map(_.contains("2")),
+      hsRecentHospitalizationReasonBoarding = hospitalizationReasons.map(_.contains("3")),
+      hsRecentHospitalizationReasonOther = hospitalizationReasons.map(_.contains("99")),
+      hsRecentHospitalizationReasonOtherDescription =
+        if (hospitalizationReasons.getOrElse(Array.empty).contains("99")) {
+          rawRecord.getOptional("hs_hosp_why_other")
+        } else {
+          None
+        },
       hsOtherMedicalInfo = rawRecord.getOptional("hs_other_med_info")
     )
   }

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
@@ -20,7 +20,7 @@ class HealthStatusTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "hs_cond_chron_change" -> Array("0"),
       "hs_congenital_yn" -> Array("0"),
       "hs_hosp_yn" -> Array("1"),
-      "hs_hosp_why" -> Array("98"),
+      "hs_hosp_why" -> Array("1", "3", "99"),
       "hs_hosp_why_other" -> Array("D'oh"),
       "hs_other_med_info" -> Array("Dog is a zombie")
     )
@@ -38,7 +38,10 @@ class HealthStatusTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     out.hsChronicConditionRecentlyChangedOrTreated.value shouldBe false
     out.hsCongenitalConditionPresent.value shouldBe false
     out.hsRecentHospitalization.value shouldBe true
-    out.hsRecentHospitalizationReason.value shouldBe 98L
+    out.hsRecentHospitalizationReasonSpayOrNeuter.value shouldBe true
+    out.hsRecentHospitalizationReasonDentistry.value shouldBe false
+    out.hsRecentHospitalizationReasonBoarding.value shouldBe true
+    out.hsRecentHospitalizationReasonOther.value shouldBe true
     out.hsRecentHospitalizationReasonOtherDescription.value shouldBe "D'oh"
     out.hsOtherMedicalInfo.value shouldBe "Dog is a zombie"
   }

--- a/schema/src/main/jade-tables/hles_dog.table.json
+++ b/schema/src/main/jade-tables/hles_dog.table.json
@@ -717,8 +717,20 @@
       "datatype": "boolean"
     },
     {
-      "name": "hs_recent_hospitalization_reason",
-      "datatype": "integer"
+      "name": "hs_recent_hospitalization_reason_spay_or_neuter",
+      "datatype": "boolean"
+    },
+    {
+      "name": "hs_recent_hospitalization_reason_dentistry",
+      "datatype": "boolean"
+    },
+    {
+      "name": "hs_recent_hospitalization_reason_boarding",
+      "datatype": "boolean"
+    },
+    {
+      "name": "hs_recent_hospitalization_reason_other",
+      "datatype": "boolean"
     },
     {
       "name": "hs_recent_hospitalization_reason_other_description",


### PR DESCRIPTION
I ran into an error running the transformation on the full dataset because the field `hs_hosp_why ` was being treated as an integer when it was really an array. I broke the values into multiple columns in the schema and updated the transformation method and tests. 

Here is the description of the `hs_hosp_why ` field for quick reference: 
```
{"field_name":"hs_hosp_why","form_name":"health_status","section_header":"","field_type":"checkbox","field_label":"Reason for hospitalization (select all that apply):","select_choices_or_calculations":"1, Spay or neuter | 2, Dentistry | 3, Boarding | 99, Other","field_note":"","text_validation_type_or_show_slider_number":"","text_validation_min":"","text_validation_max":"","identifier":"","branching_logic":"[hs_hosp_yn]='1'","required_field":"y","custom_alignment":"","question_number":"","matrix_group_name":"","matrix_ranking":"","field_annotation":""}
```