### PR TITLE
QH - DSPDC-1118 - owner_primary_residence_census_division transformations

### DIFF
--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -1,8 +1,24 @@
 package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.dogaging.jadeschema.table.HlesOwner
+import scala.util.matching.Regex
 
 object OwnerTransformations {
+
+  // Parsing the oc_primary_residence_census_division
+  // format is: "Division <N>: <some-description>"
+  val censusDivisionPattern: Regex = "Division (\\d+):".r
+
+  /**
+    * Extract the Division value from the full text string.
+    *
+    * @param divisionString the text string to be parsed
+    * @return an integer of the division number
+    **/
+  def getCensusDivision(divisionString: String): Option[Long] =
+    censusDivisionPattern
+      .findFirstMatchIn(divisionString)
+      .map(_.group(1).toLong)
 
   /** Parse all owner-related fields out of a raw RedCap record. */
   def mapOwner(rawRecord: RawRecord): HlesOwner = {
@@ -15,28 +31,6 @@ object OwnerTransformations {
     val secondaryAddress = rawRecord.getOptionalBoolean("oc_address2_yn")
     val secondaryAddressOwnership = secondaryAddress.flatMap {
       if (_) rawRecord.getOptionalNumber("oc_address2_own") else None
-    }
-    
-    // Parsing the oc_primary_residence_census_division
-    // format is: "Division <N>: <some-description>"
-    val censusDivisionPattern: Regex = "(Division \\d+:)"
-    
-    /**
-      * Extract the Division value from the full text string.
-      *
-      * @param divisionString the text string to be parsed
-      * @return an integer of the division number
-    **/
-    def getCensusDivision(divisionString: String): (integer) = {
-      val matches = censusDivisionPattern
-        .findFirstMatchIn(divisionString)
-        .getOrElse(
-          throw new Exception(
-            s"ownerTransformations: error while parsing census division id from $divisionString"
-          )
-        )
-      val censusDivisionId = matches.group(1)
-      censusDivisionId
     }
 
     HlesOwner(
@@ -66,12 +60,9 @@ object OwnerTransformations {
       ocHouseholdChildCount = rawRecord.getOptionalNumber("oc_children_household"),
       ssHouseholdDogCount = rawRecord.getOptionalNumber("ss_num_dogs_hh"),
       ocPrimaryResidenceState = rawRecord.getOptional("oc_address1_state"),
-      ocPrimaryResidenceCensusDivision = getCensusDivision(rawRecord.getOptional("oc_address1_division")),
-
-            ocSecondaryResidenceState = secondaryAddress.flatMap {
-        if (_) rawRecord.getOptional("oc_address2_state") else None
+      ocPrimaryResidenceCensusDivision = rawRecord.getOptional("oc_address1_division").flatMap {
+        getCensusDivision(_)
       },
-      
       ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
       ocPrimaryResidenceOwnership = primaryAddressOwnership,
       ocPrimaryResidenceOwnershipOtherDescription = if (primaryAddressOwnership.contains(98)) {

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap.dog
 
 import org.broadinstitute.monster.dap.RawRecord
 import org.broadinstitute.monster.dogaging.jadeschema.fragment.HlesDogResidences
+import org.broadinstitute.monster.dap.OwnerTransformations
 
 object DogResidenceTransformations {
 
@@ -29,7 +30,9 @@ object DogResidenceTransformations {
 
     HlesDogResidences(
       ocPrimaryResidenceState = rawRecord.getOptional("oc_address1_state"),
-      ocPrimaryResidenceCensusDivision = rawRecord.getOptional("oc_address1_division"),
+      ocPrimaryResidenceCensusDivision = rawRecord.getOptional("oc_address1_division").flatMap {
+        OwnerTransformations.getCensusDivision(_)
+      },
       ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
       ocPrimaryResidenceOwnership = primaryOwned,
       ocPrimaryResidenceOwnershipOtherDescription =

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -21,7 +21,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     "oc_children_household" -> Array("2"),
     "ss_num_dogs_hh" -> Array("2"),
     "oc_address1_state" -> Array("OH"),
-    "oc_address1_division" -> Array("Division 33: East North Central"),
+    "oc_address1_division" -> Array("Division 3: East North Central"),
     "oc_address1_zip" -> Array("32837-4949"),
     "oc_address1_own" -> Array("98"),
     "oc_address1_own_other" -> Array("some text"),

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -59,7 +59,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     output.ssHouseholdDogCount shouldBe Some(2)
     // residence fields
     output.ocPrimaryResidenceState shouldBe Some("OH")
-    output.ocPrimaryResidenceCensusDivision shouldBe Some("Division 3: East North Central")
+    output.ocPrimaryResidenceCensusDivision shouldBe Some(3)
     output.ocPrimaryResidenceZip shouldBe Some("32837-4949")
     output.ocPrimaryResidenceOwnership shouldBe Some(98)
     output.ocPrimaryResidenceOwnershipOtherDescription shouldBe Some("some text")

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -21,7 +21,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     "oc_children_household" -> Array("2"),
     "ss_num_dogs_hh" -> Array("2"),
     "oc_address1_state" -> Array("OH"),
-    "oc_address1_division" -> Array("Division 3: East North Central"),
+    "oc_address1_division" -> Array("Division 33: East North Central"),
     "oc_address1_zip" -> Array("32837-4949"),
     "oc_address1_own" -> Array("98"),
     "oc_address1_own_other" -> Array("some text"),

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
@@ -35,6 +35,7 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_2nd_residence_yn" -> Array("1"),
       "dd_2nd_residence_nbr" -> Array("2"),
       "oc_address1_state" -> Array("MA"),
+      "oc_address1_division" -> Array("Division 3: East North Central"),
       "oc_address1_zip" -> Array("02114"),
       "oc_address1_own" -> Array("1"),
       "oc_address1_pct" -> Array("1"),
@@ -56,6 +57,7 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
 
     val manyAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, manyAddresses))
     manyAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
+    manyAddrOut.ocPrimaryResidenceCensusDivision.value shouldBe 3L
     manyAddrOut.ocPrimaryResidenceZip.value shouldBe "02114"
     manyAddrOut.ocPrimaryResidenceOwnership.value shouldBe 1L
     manyAddrOut.ocPrimaryResidenceTimePercentage.value shouldBe 1L

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
@@ -35,7 +35,7 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_2nd_residence_yn" -> Array("1"),
       "dd_2nd_residence_nbr" -> Array("2"),
       "oc_address1_state" -> Array("MA"),
-      "oc_address1_division" -> Array("Division 3: East North Central"),
+      "oc_address1_division" -> Array("Division 33: East North Central"),
       "oc_address1_zip" -> Array("02114"),
       "oc_address1_own" -> Array("1"),
       "oc_address1_pct" -> Array("1"),
@@ -57,7 +57,7 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
 
     val manyAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, manyAddresses))
     manyAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
-    manyAddrOut.ocPrimaryResidenceCensusDivision.value shouldBe 3L
+    manyAddrOut.ocPrimaryResidenceCensusDivision.value shouldBe 33L
     manyAddrOut.ocPrimaryResidenceZip.value shouldBe "02114"
     manyAddrOut.ocPrimaryResidenceOwnership.value shouldBe 1L
     manyAddrOut.ocPrimaryResidenceTimePercentage.value shouldBe 1L

--- a/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "oc_primary_residence_census_division",
-      "datatype": "string"
+      "datatype": "integer"
     },
     {
       "name": "oc_primary_residence_zip",

--- a/schema/src/main/jade-tables/hles_owner.table.json
+++ b/schema/src/main/jade-tables/hles_owner.table.json
@@ -84,7 +84,7 @@
     },
     {
       "name": "oc_primary_residence_census_division",
-      "datatype": "string"
+      "datatype": "integer"
     },
     {
       "name": "oc_primary_residence_zip",


### PR DESCRIPTION
Updated hles_owner and hles_dog tables so that oc_primary_residence_census_division is an integer. Added transformation logic to parse the Division from the full provided string. Updated the unit test outputs to match this new logic.