### PR TITLE
QH - DSPDC-1062 - Extend hles_dog transformation to include fs_ columns

### DIFF
--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -17,7 +17,8 @@ object DogTransformations {
     hlesDogDiet = Some(DietTransformations.mapDiet(rawRecord)),
     hlesDogMedsPreventatives =
       Some(MedsAndPreventativesTransformations.mapMedsPreventatives(rawRecord)),
-    hlesDogHealthSummary = Some(HealthStatusTransformations.mapHealthSummary(rawRecord))
+    hlesDogHealthSummary = Some(HealthStatusTransformations.mapHealthSummary(rawRecord)),
+    hlesDogFutureStudies = Some(AdditionalStudiesTransformations.mapFutureStudies(rawRecord))
   )
 
 }

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -10,23 +10,29 @@ object AdditionalStudiesTransformations {
     * injecting them into a partially-modeled dog record.
     */
   def mapFutureStudies(rawRecord: RawRecord): HlesDogFutureStudies = {
-    val pcVetConsent = rawRecord.getBoolean("fs_pcvet_consent")
+    val pcVetConsent = rawRecord.getOptionalBoolean("fs_pcvet_consent")
     HlesDogFutureStudies(
       fsPrimaryCareVeterinarianExists = rawRecord.getOptionalBoolean("fs_pcvet"),
-      fsPrimaryCareVeterinarianConsentShareVemr = rawRecord.getOptionalBoolean("fs_pcvet_consent"),
-      fsPrimaryCareVeterinarianCanProvideEmail =
-        if (pcVetConsent) rawRecord.getOptionalBoolean("fs_pcvet_email_yn") else None,
-      fsPrimaryCareVeterinarianState =
-        if (pcVetConsent) rawRecord.getOptional("fs_pcvet_st") else None,
-      fsPrimaryCareVeterinarianZip =
-        if (pcVetConsent) rawRecord.getOptional("fs_pcvet_zip") else None,
+      fsPrimaryCareVeterinarianConsentShareVemr = pcVetConsent,
+      fsPrimaryCareVeterinarianCanProvideEmail = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptionalBoolean("fs_pcvet_email_yn") else None
+      },
+      fsPrimaryCareVeterinarianState = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptional("fs_pcvet_st") else None
+      },
+      fsPrimaryCareVeterinarianZip = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptional("fs_pcvet_zip") else None
+      },
       fsFutureStudiesParticipationLikelihood = rawRecord.getOptionalNumber("fs_future_studies"),
-      fsPhenotypeVsLifespanParticipationLikelihood =
-        if (pcVetConsent) rawRecord.getOptionalNumber("fs_pc_ppf_lifespan") else None,
-      fsGenotypeVsLifespanParticipationLikelihood =
-        if (pcVetConsent) rawRecord.getOptionalNumber("fs_gene_lifespan") else None,
-      fsMedicallySlowedAgingParticipationLikelihood =
-        if (pcVetConsent) rawRecord.getOptionalNumber("fs_med_aging") else None
+      fsPhenotypeVsLifespanParticipationLikelihood = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptionalNumber("fs_pc_ppf_lifespan") else None
+      },
+      fsGenotypeVsLifespanParticipationLikelihood = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptionalNumber("fs_gene_lifespan") else None
+      },
+      fsMedicallySlowedAgingParticipationLikelihood = pcVetConsent.flatMap {
+        if (_) rawRecord.getOptionalNumber("fs_med_aging") else None
+      }
     )
   }
 }

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.HlesDogFutureStudies
+
+object AdditionalStudiesTransformations {
+
+  /**
+    * Parse all future-studies health fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapFutureStudies(rawRecord: RawRecord): HlesDogFutureStudies = {
+    val init = HlesDogFutureStudies.init()
+
+    val transformations = List(
+      mapFutureStudiesFields _
+    )
+
+    transformations.foldLeft(init)((acc, f) => f(rawRecord, acc))
+  }
+
+  /**
+    * Parse primary care vet and participation likelihood fields out of a
+    * raw RedCap record, injecting them into a partially-modeled dog record.
+    */
+  def mapFutureStudiesFields(
+    rawRecord: RawRecord,
+    dog: HlesDogFutureStudies
+  ): HlesDogFutureStudies = {
+    val pcVetConsent = rawRecord.getBoolean("fs_pcvet_consent")
+    dog.copy(
+      fsPrimaryCareVeterinarianExists = rawRecord.getOptionalBoolean("fs_pcvet"),
+      fsPrimaryCareVeterinarianConsentShareVemr = rawRecord.getOptionalBoolean("fs_pcvet_consent"),
+      fsPrimaryCareVeterinarianCanProvideEmail =
+        if (pcVetConsent) rawRecord.getOptionalBoolean("fs_pcvet_email_yn") else None,
+      fsPrimaryCareVeterinarianState =
+        if (pcVetConsent) rawRecord.getOptional("fs_pcvet_st") else None,
+      fsPrimaryCareVeterinarianZip =
+        if (pcVetConsent) rawRecord.getOptional("fs_pcvet_zip") else None,
+      fsFutureStudiesParticipationLikelihood = rawRecord.getOptionalNumber("fs_future_studies"),
+      fsPhenotypeVsLifespanParticipationLikelihood =
+        if (pcVetConsent) rawRecord.getOptionalNumber("fs_pc_ppf_lifespan") else None,
+      fsGenotypeVsLifespanParticipationLikelihood =
+        if (pcVetConsent) rawRecord.getOptionalNumber("fs_gene_lifespan") else None,
+      fsMedicallySlowedAgingParticipationLikelihood =
+        if (pcVetConsent) rawRecord.getOptionalNumber("fs_med_aging") else None
+    )
+  }
+}

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -10,25 +10,8 @@ object AdditionalStudiesTransformations {
     * injecting them into a partially-modeled dog record.
     */
   def mapFutureStudies(rawRecord: RawRecord): HlesDogFutureStudies = {
-    val init = HlesDogFutureStudies.init()
-
-    val transformations = List(
-      mapFutureStudiesFields _
-    )
-
-    transformations.foldLeft(init)((acc, f) => f(rawRecord, acc))
-  }
-
-  /**
-    * Parse primary care vet and participation likelihood fields out of a
-    * raw RedCap record, injecting them into a partially-modeled dog record.
-    */
-  def mapFutureStudiesFields(
-    rawRecord: RawRecord,
-    dog: HlesDogFutureStudies
-  ): HlesDogFutureStudies = {
     val pcVetConsent = rawRecord.getBoolean("fs_pcvet_consent")
-    dog.copy(
+    HlesDogFutureStudies(
       fsPrimaryCareVeterinarianExists = rawRecord.getOptionalBoolean("fs_pcvet"),
       fsPrimaryCareVeterinarianConsentShareVemr = rawRecord.getOptionalBoolean("fs_pcvet_consent"),
       fsPrimaryCareVeterinarianCanProvideEmail =

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -21,7 +21,8 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
       hlesDogDiet = Some(HlesDogDiet.init()),
       hlesDogHealthSummary = Some(HlesDogHealthSummary.init()),
       hlesDogPhysicalActivity = Some(HlesDogPhysicalActivity.init()),
-      hlesDogMedsPreventatives = Some(HlesDogMedsPreventatives.init())
+      hlesDogMedsPreventatives = Some(HlesDogMedsPreventatives.init()),
+      hlesDogFutureStudies = Some(HlesDogFutureStudies.init())
     )
   }
 }

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -58,7 +58,7 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     // output of a record without primary care vet consent
     lacksConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
     lacksConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe false
-    lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe false
+    lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe None
     lacksConsentOut.fsPrimaryCareVeterinarianState.value shouldBe None
     lacksConsentOut.fsPrimaryCareVeterinarianZip.value shouldBe None
     lacksConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 3L

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -1,0 +1,69 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.HlesDogFutureStudies
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  behavior of "AdditionalStatusTransformations"
+
+  it should "map future-studies info with consent" in {
+    val hasConsentExample = Map(
+      //TODO need examples of valid data
+      "fs_pcvet" -> Array("1"),
+      "fs_pcvet_consent" -> Array("1"),
+      "fs_pcvet_email_yn" -> Array("1"),
+      "fs_pcvet_st" -> Array("MA"),
+      "fs_pcvet_zip" -> Array("02062-4444"),
+      "fs_future_studies" -> Array("88"),
+      "fs_pc_ppf_lifespan" -> Array("87"),
+      "fs_gene_lifespan" -> Array("86"),
+      "fs_med_aging" -> Array("85")
+    )
+    val lacksConsentExample = Map(
+      //TODO need examples of valid data
+      "fs_pcvet" -> Array("1"),
+      "fs_pcvet_consent" -> Array("2"),
+      "fs_pcvet_email_yn" -> Array("1"),
+      "fs_pcvet_st" -> Array("MA"),
+      "fs_pcvet_zip" -> Array("02062-4444"),
+      "fs_future_studies" -> Array("3"),
+      "fs_pc_ppf_lifespan" -> Array("2"),
+      "fs_gene_lifespan" -> Array("5"),
+      "fs_med_aging" -> Array("11")
+    )
+    val hasConsentOut = AdditionalStudiesTransformations.mapFutureStudiesFields(
+      RawRecord(1, hasConsentExample),
+      HlesDogFutureStudies.init()
+    )
+
+    val lacksConsentOut = AdditionalStudiesTransformations.mapFutureStudiesFields(
+      RawRecord(1, lacksConsentExample),
+      HlesDogFutureStudies.init()
+    )
+    // output of a record with primary care vet consent
+    hasConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianState.value shouldBe "MA"
+    hasConsentOut.fsPrimaryCareVeterinarianZip.value shouldBe "02062-4444"
+    hasConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 88L
+    hasConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe 87L
+    hasConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe 86L
+    hasConsentOut.fsMedicallySlowedAgingParticipationLikelihood.value shouldBe 85L
+
+    // output of a record without primary care vet consent
+    lacksConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
+    lacksConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe false
+    lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe false
+    lacksConsentOut.fsPrimaryCareVeterinarianState.value shouldBe None
+    lacksConsentOut.fsPrimaryCareVeterinarianZip.value shouldBe None
+    lacksConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 3L
+    lacksConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe None
+    lacksConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe None
+    lacksConsentOut.fsMedicallySlowedAgingParticipationLikelihood.value shouldBe None
+  }
+}

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.monster.dap.dog
 
 import org.broadinstitute.monster.dap.RawRecord
-import org.broadinstitute.monster.dogaging.jadeschema.fragment.HlesDogFutureStudies
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -12,7 +11,6 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
 
   it should "map future-studies info with consent" in {
     val hasConsentExample = Map(
-      //TODO need examples of valid data
       "fs_pcvet" -> Array("1"),
       "fs_pcvet_consent" -> Array("1"),
       "fs_pcvet_email_yn" -> Array("1"),
@@ -23,27 +21,11 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
       "fs_gene_lifespan" -> Array("86"),
       "fs_med_aging" -> Array("85")
     )
-    val lacksConsentExample = Map(
-      //TODO need examples of valid data
-      "fs_pcvet" -> Array("1"),
-      "fs_pcvet_consent" -> Array("2"),
-      "fs_pcvet_email_yn" -> Array("1"),
-      "fs_pcvet_st" -> Array("MA"),
-      "fs_pcvet_zip" -> Array("02062-4444"),
-      "fs_future_studies" -> Array("3"),
-      "fs_pc_ppf_lifespan" -> Array("2"),
-      "fs_gene_lifespan" -> Array("5"),
-      "fs_med_aging" -> Array("11")
-    )
-    val hasConsentOut = AdditionalStudiesTransformations.mapFutureStudiesFields(
-      RawRecord(1, hasConsentExample),
-      HlesDogFutureStudies.init()
+
+    val hasConsentOut = AdditionalStudiesTransformations.mapFutureStudies(
+      RawRecord(1, hasConsentExample)
     )
 
-    val lacksConsentOut = AdditionalStudiesTransformations.mapFutureStudiesFields(
-      RawRecord(1, lacksConsentExample),
-      HlesDogFutureStudies.init()
-    )
     // output of a record with primary care vet consent
     hasConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
     hasConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe true
@@ -54,6 +36,24 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     hasConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe 87L
     hasConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe 86L
     hasConsentOut.fsMedicallySlowedAgingParticipationLikelihood.value shouldBe 85L
+  }
+
+  it should "not map future-studies info without consent" in {
+    val lacksConsentExample = Map(
+      "fs_pcvet" -> Array("1"),
+      "fs_pcvet_consent" -> Array("2"),
+      "fs_pcvet_email_yn" -> Array("1"),
+      "fs_pcvet_st" -> Array("MA"),
+      "fs_pcvet_zip" -> Array("02062-4444"),
+      "fs_future_studies" -> Array("3"),
+      "fs_pc_ppf_lifespan" -> Array("2"),
+      "fs_gene_lifespan" -> Array("5"),
+      "fs_med_aging" -> Array("11")
+    )
+
+    val lacksConsentOut = AdditionalStudiesTransformations.mapFutureStudies(
+      RawRecord(1, lacksConsentExample)
+    )
 
     // output of a record without primary care vet consent
     lacksConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -58,12 +58,12 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     // output of a record without primary care vet consent
     lacksConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
     lacksConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe false
-    lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe None
-    lacksConsentOut.fsPrimaryCareVeterinarianState.value shouldBe None
-    lacksConsentOut.fsPrimaryCareVeterinarianZip.value shouldBe None
+    lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail shouldBe None
+    lacksConsentOut.fsPrimaryCareVeterinarianState shouldBe None
+    lacksConsentOut.fsPrimaryCareVeterinarianZip shouldBe None
     lacksConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 3L
-    lacksConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe None
-    lacksConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe None
-    lacksConsentOut.fsMedicallySlowedAgingParticipationLikelihood.value shouldBe None
+    lacksConsentOut.fsPhenotypeVsLifespanParticipationLikelihood shouldBe None
+    lacksConsentOut.fsGenotypeVsLifespanParticipationLikelihood shouldBe None
+    lacksConsentOut.fsMedicallySlowedAgingParticipationLikelihood shouldBe None
   }
 }

--- a/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
@@ -1,0 +1,41 @@
+{
+  "name": "hles_dog_future_studies",
+  "columns": [
+    { 
+      "name": "fs_primary_care_veterinarian_exists",
+      "datatype": "boolean"
+    },
+    { 
+      "name": "fs_primary_care_veterinarian_consent_share_vemr",
+      "datatype": "boolean"
+    },
+    { 
+      "name": "fs_primary_care_veterinarian_can_provide_email",
+      "datatype": "boolean"
+    },
+    { 
+      "name": "fs_primary_care_veterinarian_state",
+      "datatype": "string"
+    },
+    { 
+      "name": "fs_primary_care_veterinarian_zip",
+      "datatype": "string"
+    },
+    { 
+      "name": "fs_future_studies_participation_likelihood",
+      "datatype": "integer"
+    },
+    { 
+      "name": "fs_phenotype_vs_lifespan_participation_likelihood",
+      "datatype": "integer"
+    },
+    { 
+      "name": "fs_genotype_vs_lifespan_participation_likelihood",
+      "datatype": "integer"
+    },
+    { 
+      "name": "fs_medically_slowed_aging_participation_likelihood",
+      "datatype": "integer"
+    }
+  ]
+}

--- a/schema/src/main/jade-tables/hles_dog.table.json
+++ b/schema/src/main/jade-tables/hles_dog.table.json
@@ -26,6 +26,7 @@
     "hles_dog_behavior",
     "hles_dog_diet",
     "hles_dog_meds_preventatives",
-    "hles_dog_health_summary"
+    "hles_dog_health_summary",
+    "hles_dog_future_studies"
   ]
 }


### PR DESCRIPTION
Added an additional fragment to the hles_dog.table (hles_dog_future_studies).
Added a new file under jade-fragments to store the future studies fields and datatypes.
Extended the DogTransformations code to process hlesDogFutureStudies.
Added a new transformation file for AdditionalStudiesTransformations.
Transformation logic check for primary care vet consent before filling out certain fields.
Added a unit test for AdditionalStudiesTransformation logic with two test cases - with consent and without consent.