### PR TITLE
SW-DSPDC-1058 transform dog residential environment

### DIFF
--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -13,6 +13,8 @@ object DogTransformations {
     hlesDogDemographics = Some(DemographicsTransformations.mapDemographics(rawRecord)),
     hlesDogResidences = Some(DogResidenceTransformations.mapDogResidences(rawRecord)),
     hlesDogPhysicalActivity = Some(PhysicalActivityTransformations.mapPhysicalActivity(rawRecord)),
+    hlesDogResidentialEnvironment =
+      Some(ResidentialEnvironmentTransformations.mapResidentialEnvironment(rawRecord)),
     hlesDogBehavior = Some(BehaviorTransformations.mapBehavior(rawRecord)),
     hlesDogDiet = Some(DietTransformations.mapDiet(rawRecord)),
     hlesDogMedsPreventatives =
@@ -20,5 +22,4 @@ object DogTransformations {
     hlesDogHealthSummary = Some(HealthStatusTransformations.mapHealthSummary(rawRecord)),
     hlesDogFutureStudies = Some(AdditionalStudiesTransformations.mapFutureStudies(rawRecord))
   )
-
 }

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -44,9 +44,11 @@ object ResidentialEnvironmentTransformations {
       dog.copy(
         deLifetimeResidenceCount = Some(totalResidenceCount),
         dePastResidenceZipCount = Some(pastZipCount),
-        dePastResidenceZip1 =
-          if (pastZipCount > 1) rawRecord.getOptional("de_zip_01")
-          else rawRecord.getOptional("de_zip_01_only"),
+        dePastResidenceZip1 = if (pastZipCount > 1) {
+          rawRecord.getOptional("de_zip_01")
+        } else {
+          rawRecord.getOptional("de_zip_01_only")
+        },
         dePastResidenceZip2 = if (pastZipCount > 1) rawRecord.getOptional("de_zip_02") else None,
         dePastResidenceZip3 = if (pastZipCount > 2) rawRecord.getOptional("de_zip_03") else None,
         dePastResidenceZip4 = if (pastZipCount > 3) rawRecord.getOptional("de_zip_04") else None,
@@ -57,9 +59,11 @@ object ResidentialEnvironmentTransformations {
         dePastResidenceZip9 = if (pastZipCount > 8) rawRecord.getOptional("de_zip_09") else None,
         dePastResidenceZip10 = if (pastZipCount > 9) rawRecord.getOptional("de_zip_10") else None,
         dePastResidenceCountryCount = Some(pastCountryCount),
-        dePastResidenceCountry1 =
-          if (pastCountryCount > 1) rawRecord.getOptional("de_country_01")
-          else rawRecord.getOptional("de_country_01_only"),
+        dePastResidenceCountry1 = if (pastCountryCount > 1) {
+          rawRecord.getOptional("de_country_01")
+        } else {
+          rawRecord.getOptional("de_country_01_only")
+        },
         dePastResidenceCountry2 =
           if (pastCountryCount > 1) rawRecord.getOptional("de_country_02") else None,
         dePastResidenceCountry3 =
@@ -79,7 +83,9 @@ object ResidentialEnvironmentTransformations {
         dePastResidenceCountry10 =
           if (pastCountryCount > 9) rawRecord.getOptional("de_country_10") else None
       )
-    } else dog.copy()
+    } else {
+      dog.copy()
+    }
   }
 
   /**
@@ -113,9 +119,11 @@ object ResidentialEnvironmentTransformations {
       if (secondaryHeatUsed.contains(1L)) rawRecord.getOptionalNumber("de_secondary_heat") else None
     val primaryStove = rawRecord.getOptionalNumber("de_primary_stove")
     val secondaryStoveUsed = rawRecord.getOptionalNumber("de_secondary_stove_yn")
-    val secondaryStove =
-      if (secondaryStoveUsed.contains(1L)) rawRecord.getOptionalNumber("de_secondary_stove")
-      else None
+    val secondaryStove = if (secondaryStoveUsed.contains(1L)) {
+      rawRecord.getOptionalNumber("de_secondary_stove")
+    } else {
+      None
+    }
     dog.copy(
       dePrimaryHeatFuel = primaryHeat,
       dePrimaryHeatFuelOtherDescription =
@@ -129,9 +137,11 @@ object ResidentialEnvironmentTransformations {
         if (primaryStove.contains(98L)) rawRecord.getOptional("de_primary_stove_other") else None,
       deSecondaryStoveFuelUsed = secondaryStoveUsed,
       deSecondaryStoveFuel = secondaryStove,
-      deSecondaryStoveFuelOtherDescription =
-        if (secondaryStove.contains(98L)) rawRecord.getOptional("de_secondary_stove_other")
-        else None
+      deSecondaryStoveFuelOtherDescription = if (secondaryStove.contains(98L)) {
+        rawRecord.getOptional("de_secondary_stove_other")
+      } else {
+        None
+      }
     )
   }
 
@@ -186,9 +196,11 @@ object ResidentialEnvironmentTransformations {
       deHepaPresent = rawRecord.getOptionalNumber("de_hepa"),
       deWoodFireplacePresent = woodFireplace,
       deGasFireplacePresent = gasFireplace,
-      deWoodFireplaceLightingsPerWeek =
-        if (woodFireplace.contains(1L)) rawRecord.getOptionalNumber("de_wood_fireplace_lit")
-        else None,
+      deWoodFireplaceLightingsPerWeek = if (woodFireplace.contains(1L)) {
+        rawRecord.getOptionalNumber("de_wood_fireplace_lit")
+      } else {
+        None
+      },
       deGasFireplaceLightingsPerWeek =
         if (gasFireplace.contains(1L)) rawRecord.getOptionalNumber("de_gas_fireplace_lit") else None
     )
@@ -219,20 +231,26 @@ object ResidentialEnvironmentTransformations {
       deFloorFrequencyOnCarpet =
         if (hasCarpet.contains(true)) rawRecord.getOptionalNumber("de_floor_carpet_freq") else None,
       deFloorTypesConcrete = hasConcrete,
-      deFloorFrequencyOnConcrete =
-        if (hasConcrete.contains(true)) rawRecord.getOptionalNumber("de_floor_concrete_freq")
-        else None,
+      deFloorFrequencyOnConcrete = if (hasConcrete.contains(true)) {
+        rawRecord.getOptionalNumber("de_floor_concrete_freq")
+      } else {
+        None
+      },
       deFloorTypesTile = hasTile,
       deFloorFrequencyOnTile =
         if (hasTile.contains(true)) rawRecord.getOptionalNumber("de_floor_tile_freq") else None,
       deFloorTypesLinoleum = hasLinoleum,
-      deFloorFrequencyOnLinoleum =
-        if (hasLinoleum.contains(true)) rawRecord.getOptionalNumber("de_floor_linoleum_freq")
-        else None,
+      deFloorFrequencyOnLinoleum = if (hasLinoleum.contains(true)) {
+        rawRecord.getOptionalNumber("de_floor_linoleum_freq")
+      } else {
+        None
+      },
       deFloorTypesLaminate = hasLaminate,
-      deFloorFrequencyOnLaminate =
-        if (hasLaminate.contains(true)) rawRecord.getOptionalNumber("de_floor_laminate_freq")
-        else None,
+      deFloorFrequencyOnLaminate = if (hasLaminate.contains(true)) {
+        rawRecord.getOptionalNumber("de_floor_laminate_freq")
+      } else {
+        None
+      },
       deFloorTypesOther = hasOther,
       deFloorTypesOtherDescription =
         if (hasOther.contains(true)) rawRecord.getOptional("de_floor_other") else None,
@@ -253,9 +271,11 @@ object ResidentialEnvironmentTransformations {
     dog: HlesDogResidentialEnvironment
   ): HlesDogResidentialEnvironment = {
     val propertyAccess = rawRecord.getOptionalBoolean("de_property_access_yn")
-    val containmentType =
-      if (propertyAccess.contains(true)) rawRecord.getOptionalNumber("de_property_fence_yn")
-      else None
+    val containmentType = if (propertyAccess.contains(true)) {
+      rawRecord.getOptionalNumber("de_property_fence_yn")
+    } else {
+      None
+    }
     val drinkingWaterSources = rawRecord.get("de_outside_water")
     val drinkingWaterOther = drinkingWaterSources.map(_.contains("98"))
     val weedControl = rawRecord.getOptionalNumber("de_yard_weed_ctl_yn")
@@ -264,27 +284,37 @@ object ResidentialEnvironmentTransformations {
     dog.copy(
       dePropertyArea = rawRecord.getOptionalNumber("de_property_size"),
       dePropertyAccessible = propertyAccess,
-      dePropertyAreaAccessible =
-        if (propertyAccess.contains(true)) rawRecord.getOptionalNumber("de_property_access")
-        else None,
+      dePropertyAreaAccessible = if (propertyAccess.contains(true)) {
+        rawRecord.getOptionalNumber("de_property_access")
+      } else {
+        None
+      },
       dePropertyContainmentType = containmentType,
-      dePropertyContainmentTypeOtherDescription =
-        if (containmentType.contains(4L)) rawRecord.getOptional("de_property_fence_other")
-        else None,
+      dePropertyContainmentTypeOtherDescription = if (containmentType.contains(4L)) {
+        rawRecord.getOptional("de_property_fence_other")
+      } else {
+        None
+      },
       dePropertyDrinkingWaterBowl = drinkingWaterSources.map(_.contains("1")),
       dePropertyDrinkingWaterHose = drinkingWaterSources.map(_.contains("2")),
       dePropertyDrinkingWaterPuddles = drinkingWaterSources.map(_.contains("3")),
       dePropertyDrinkingWaterUnknown = drinkingWaterSources.map(_.contains("99")),
       dePropertyDrinkingWaterOther = drinkingWaterOther,
-      dePropertyDrinkingWaterOtherDescription =
-        if (drinkingWaterOther.contains(true)) rawRecord.getOptional("de_outside_water_other")
-        else None,
-      dePropertyWeedControlFrequency =
-        if (weedControl.contains(1L)) rawRecord.getOptionalNumber("de_yard_weed_ctl_freq")
-        else weedControl,
-      dePropertyPestControlFrequency =
-        if (pestControl.contains(1L)) rawRecord.getOptionalNumber("de_yard_pest_ctl_freq")
-        else pestControl
+      dePropertyDrinkingWaterOtherDescription = if (drinkingWaterOther.contains(true)) {
+        rawRecord.getOptional("de_outside_water_other")
+      } else {
+        None
+      },
+      dePropertyWeedControlFrequency = if (weedControl.contains(1L)) {
+        rawRecord.getOptionalNumber("de_yard_weed_ctl_freq")
+      } else {
+        weedControl
+      },
+      dePropertyPestControlFrequency = if (pestControl.contains(1L)) {
+        rawRecord.getOptionalNumber("de_yard_pest_ctl_freq")
+      } else {
+        pestControl
+      }
     )
   }
 
@@ -304,15 +334,17 @@ object ResidentialEnvironmentTransformations {
       deNeighborhoodHasSidewalks = rawRecord.getOptionalNumber("de_sidewalk_yn"),
       deNeighborhoodHasParks = rawRecord.getOptionalBoolean("de_parks_near"),
       deInteractsWithNeighborhoodAnimals = animalsInteract,
-      deInteractsWithNeighborhoodAnimalsWithoutOwner =
-        if (animalsInteract.contains(true))
-          rawRecord.getOptionalBoolean("de_animal_interact_present").map(!_)
-        else None,
+      deInteractsWithNeighborhoodAnimalsWithoutOwner = if (animalsInteract.contains(true)) {
+        rawRecord.getOptionalBoolean("de_animal_interact_present").map(!_)
+      } else {
+        None
+      },
       deInteractsWithNeighborhoodHumans = humansInteract,
-      deInteractsWithNeighborhoodHumansWithoutOwner =
-        if (humansInteract.contains(true))
-          rawRecord.getOptionalBoolean("de_human_interact_present").map(!_)
-        else None
+      deInteractsWithNeighborhoodHumansWithoutOwner = if (humansInteract.contains(true)) {
+        rawRecord.getOptionalBoolean("de_human_interact_present").map(!_)
+      } else {
+        None
+      }
     )
   }
 }

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -1,0 +1,318 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.HlesDogResidentialEnvironment
+
+object ResidentialEnvironmentTransformations {
+
+  /** Map all residential environment fields out of a raw RedCap record into a partial Dog model. */
+  def mapResidentialEnvironment(rawRecord: RawRecord): HlesDogResidentialEnvironment = {
+    val init = HlesDogResidentialEnvironment.init()
+
+    val transformations = List(
+      mapPastResidences _,
+      mapHouse _,
+      mapHeating _,
+      mapDrinkingWater _,
+      mapToxinExposure _,
+      mapFlooring _,
+      mapProperty _,
+      mapNeighborhood _
+    )
+
+    transformations.foldLeft(init)((acc, f) => f(rawRecord, acc))
+  }
+
+  /**
+    * Parse all past-residence-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapPastResidences(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val secondaryHome = rawRecord.getOptionalBoolean("oc_address2_yn")
+    val pastResidenceCount = rawRecord.getOptionalNumber("de_home_nbr")
+    if (secondaryHome.isDefined && pastResidenceCount.isDefined) {
+      val currentResidenceCount = if (secondaryHome.head) 2 else 1
+      val totalResidenceCount = pastResidenceCount.head + currentResidenceCount
+      val pastZipCount =
+        if (totalResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
+      val pastCountryCount =
+        if (totalResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
+
+      dog.copy(
+        deLifetimeResidenceCount = Some(totalResidenceCount),
+        dePastResidenceZipCount = Some(pastZipCount),
+        dePastResidenceZip1 =
+          if (pastZipCount > 1) rawRecord.getOptional("de_zip_01")
+          else rawRecord.getOptional("de_zip_01_only"),
+        dePastResidenceZip2 = if (pastZipCount > 1) rawRecord.getOptional("de_zip_02") else None,
+        dePastResidenceZip3 = if (pastZipCount > 2) rawRecord.getOptional("de_zip_03") else None,
+        dePastResidenceZip4 = if (pastZipCount > 3) rawRecord.getOptional("de_zip_04") else None,
+        dePastResidenceZip5 = if (pastZipCount > 4) rawRecord.getOptional("de_zip_05") else None,
+        dePastResidenceZip6 = if (pastZipCount > 5) rawRecord.getOptional("de_zip_06") else None,
+        dePastResidenceZip7 = if (pastZipCount > 6) rawRecord.getOptional("de_zip_07") else None,
+        dePastResidenceZip8 = if (pastZipCount > 7) rawRecord.getOptional("de_zip_08") else None,
+        dePastResidenceZip9 = if (pastZipCount > 8) rawRecord.getOptional("de_zip_09") else None,
+        dePastResidenceZip10 = if (pastZipCount > 9) rawRecord.getOptional("de_zip_10") else None,
+        dePastResidenceCountryCount = Some(pastCountryCount),
+        dePastResidenceCountry1 =
+          if (pastCountryCount > 1) rawRecord.getOptional("de_country_01")
+          else rawRecord.getOptional("de_country_01_only"),
+        dePastResidenceCountry2 =
+          if (pastCountryCount > 1) rawRecord.getOptional("de_country_02") else None,
+        dePastResidenceCountry3 =
+          if (pastCountryCount > 2) rawRecord.getOptional("de_country_03") else None,
+        dePastResidenceCountry4 =
+          if (pastCountryCount > 3) rawRecord.getOptional("de_country_04") else None,
+        dePastResidenceCountry5 =
+          if (pastCountryCount > 4) rawRecord.getOptional("de_country_05") else None,
+        dePastResidenceCountry6 =
+          if (pastCountryCount > 5) rawRecord.getOptional("de_country_06") else None,
+        dePastResidenceCountry7 =
+          if (pastCountryCount > 6) rawRecord.getOptional("de_country_07") else None,
+        dePastResidenceCountry8 =
+          if (pastCountryCount > 7) rawRecord.getOptional("de_country_08") else None,
+        dePastResidenceCountry9 =
+          if (pastCountryCount > 8) rawRecord.getOptional("de_country_09") else None,
+        dePastResidenceCountry10 =
+          if (pastCountryCount > 9) rawRecord.getOptional("de_country_10") else None
+      )
+    } else dog.copy()
+  }
+
+  /**
+    * Parse high-level house-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapHouse(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment =
+    dog.copy(
+      deHomeAreaType = rawRecord.getOptionalNumber("de_type_area"),
+      deHomeType = rawRecord.getOptionalNumber("de_type_home"),
+      deHomeTypeOtherDescription = rawRecord.getOptional("he_type_home_other"),
+      deHomeConstructionDecade = rawRecord.getOptionalNumber("de_home_age"),
+      deHomeYearsLivedIn = rawRecord.getOptionalNumber("de_home_lived_years"),
+      deHomeSquareFootage = rawRecord.getOptionalNumber("de_home_area")
+    )
+
+  /**
+    * Parse heating-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapHeating(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val primaryHeat = rawRecord.getOptionalNumber("de_primary_heat")
+    val secondaryHeatUsed = rawRecord.getOptionalNumber("de_secondary_heat_yn")
+    val secondaryHeat =
+      if (secondaryHeatUsed.contains(1L)) rawRecord.getOptionalNumber("de_secondary_heat") else None
+    val primaryStove = rawRecord.getOptionalNumber("de_primary_stove")
+    val secondaryStoveUsed = rawRecord.getOptionalNumber("de_secondary_stove_yn")
+    val secondaryStove =
+      if (secondaryStoveUsed.contains(1L)) rawRecord.getOptionalNumber("de_secondary_stove")
+      else None
+    dog.copy(
+      dePrimaryHeatFuel = primaryHeat,
+      dePrimaryHeatFuelOtherDescription =
+        if (primaryHeat.contains(98L)) rawRecord.getOptional("de_primary_heat_other") else None,
+      deSecondaryHeatFuelUsed = secondaryHeatUsed,
+      deSecondaryHeatFuel = secondaryHeat,
+      deSecondaryHeatFuelOtherDescription =
+        if (secondaryHeat.contains(98L)) rawRecord.getOptional("de_secondary_heat_other") else None,
+      dePrimaryStoveFuel = primaryStove,
+      dePrimaryStoveFuelOtherDescription =
+        if (primaryStove.contains(98L)) rawRecord.getOptional("de_primary_stove_other") else None,
+      deSecondaryStoveFuelUsed = secondaryStoveUsed,
+      deSecondaryStoveFuel = secondaryStove,
+      deSecondaryStoveFuelOtherDescription =
+        if (secondaryStove.contains(98L)) rawRecord.getOptional("de_secondary_stove_other")
+        else None
+    )
+  }
+
+  /**
+    * Parse drinking-water-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapDrinkingWater(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val source = rawRecord.getOptionalNumber("de_water_source")
+    val knownPipes = rawRecord.getOptionalBoolean("de_pipe_yn")
+    val pipeType = knownPipes match {
+      case Some(false) => Some(99L) // unknown type
+      case Some(true)  => rawRecord.getOptionalNumber("de_pipe_type")
+      case None        => None
+    }
+    dog.copy(
+      deDrinkingWaterSource = source,
+      deDrinkingWaterSourceOtherDescription =
+        if (source.contains(98L)) rawRecord.getOptional("de_water_source_other") else None,
+      deDrinkingWaterIsFiltered = rawRecord.getOptionalNumber("de_water_filter_yn"),
+      dePipeType = pipeType,
+      dePipeTypeOtherDescription =
+        if (pipeType.contains(98L)) rawRecord.getOptional("de_pipe_type_other") else None
+    )
+  }
+
+  /**
+    * Parse toxin-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapToxinExposure(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val woodFireplace = rawRecord.getOptionalNumber("de_wood_burning")
+    val gasFireplace = rawRecord.getOptionalNumber("de_gas_fireplace")
+    dog.copy(
+      deSecondHandSmokeHoursPerDay = rawRecord.getOptionalNumber("de_2nd_hand_smoke_amt"),
+      deCentralAirConditioningPresent = rawRecord.getOptionalNumber("de_central_ac"),
+      deRoomOrWindowAirConditioningPresent = rawRecord.getOptionalNumber("de_room_ac"),
+      deCentralHeatPresent = rawRecord.getOptionalNumber("de_central_heat"),
+      deAsbestosPresent = rawRecord.getOptionalNumber("de_asbestos"),
+      deRadonPresent = rawRecord.getOptionalNumber("de_radon"),
+      deLeadPresent = rawRecord.getOptionalNumber("de_lead"),
+      deMothballPresent = rawRecord.getOptionalNumber("de_mothball"),
+      deIncensePresent = rawRecord.getOptionalNumber("de_incense"),
+      deAirFreshenerPresent = rawRecord.getOptionalNumber("de_air_freshener"),
+      deAirCleanerPresent = rawRecord.getOptionalNumber("de_air_cleaner"),
+      deHepaPresent = rawRecord.getOptionalNumber("de_hepa"),
+      deWoodFireplacePresent = woodFireplace,
+      deGasFireplacePresent = gasFireplace,
+      deWoodFireplaceLightingsPerWeek =
+        if (woodFireplace.contains(1L)) rawRecord.getOptionalNumber("de_wood_fireplace_lit")
+        else None,
+      deGasFireplaceLightingsPerWeek =
+        if (gasFireplace.contains(1L)) rawRecord.getOptionalNumber("de_gas_fireplace_lit") else None
+    )
+  }
+
+  /**
+    * Parse flooring-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapFlooring(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val hasWood = rawRecord.getOptionalBoolean("de_floor_wood_yn")
+    val hasCarpet = rawRecord.getOptionalBoolean("de_floor_carpet_yn")
+    val hasConcrete = rawRecord.getOptionalBoolean("de_floor_concrete_yn")
+    val hasTile = rawRecord.getOptionalBoolean("de_floor_tile_yn")
+    val hasLinoleum = rawRecord.getOptionalBoolean("de_floor_linoleum_yn")
+    val hasLaminate = rawRecord.getOptionalBoolean("de_floor_laminate_yn")
+    val hasOther = rawRecord.getOptionalBoolean("de_floor_other_yn")
+    val hasStairs = rawRecord.getOptionalBoolean("de_stairs")
+
+    dog.copy(
+      deFloorTypesWood = hasWood,
+      deFloorFrequencyOnWood =
+        if (hasWood.contains(true)) rawRecord.getOptionalNumber("de_floor_wood_freq") else None,
+      deFloorTypesCarpet = hasCarpet,
+      deFloorFrequencyOnCarpet =
+        if (hasCarpet.contains(true)) rawRecord.getOptionalNumber("de_floor_carpet_freq") else None,
+      deFloorTypesConcrete = hasConcrete,
+      deFloorFrequencyOnConcrete =
+        if (hasConcrete.contains(true)) rawRecord.getOptionalNumber("de_floor_concrete_freq")
+        else None,
+      deFloorTypesTile = hasTile,
+      deFloorFrequencyOnTile =
+        if (hasTile.contains(true)) rawRecord.getOptionalNumber("de_floor_tile_freq") else None,
+      deFloorTypesLinoleum = hasLinoleum,
+      deFloorFrequencyOnLinoleum =
+        if (hasLinoleum.contains(true)) rawRecord.getOptionalNumber("de_floor_linoleum_freq")
+        else None,
+      deFloorTypesLaminate = hasLaminate,
+      deFloorFrequencyOnLaminate =
+        if (hasLaminate.contains(true)) rawRecord.getOptionalNumber("de_floor_laminate_freq")
+        else None,
+      deFloorTypesOther = hasOther,
+      deFloorTypesOtherDescription =
+        if (hasOther.contains(true)) rawRecord.getOptional("de_floor_other") else None,
+      deFloorFrequencyOnOther =
+        if (hasOther.contains(true)) rawRecord.getOptionalNumber("de_floor_other_freq") else None,
+      deStairsInHome = hasStairs,
+      deStairsAvgFlightsPerDay =
+        if (hasStairs.contains(true)) rawRecord.getOptionalNumber("de_stairs_nbr") else None
+    )
+  }
+
+  /**
+    * Parse property-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapProperty(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val propertyAccess = rawRecord.getOptionalBoolean("de_property_access_yn")
+    val containmentType =
+      if (propertyAccess.contains(true)) rawRecord.getOptionalNumber("de_property_fence_yn")
+      else None
+    val drinkingWaterSources = rawRecord.get("de_outside_water")
+    val drinkingWaterOther = drinkingWaterSources.map(_.contains("98"))
+    val weedControl = rawRecord.getOptionalNumber("de_yard_weed_ctl_yn")
+    val pestControl = rawRecord.getOptionalNumber("de_yard_pest_ctl_yn")
+
+    dog.copy(
+      dePropertyArea = rawRecord.getOptionalNumber("de_property_size"),
+      dePropertyAccessible = propertyAccess,
+      dePropertyAreaAccessible =
+        if (propertyAccess.contains(true)) rawRecord.getOptionalNumber("de_property_access")
+        else None,
+      dePropertyContainmentType = containmentType,
+      dePropertyContainmentTypeOtherDescription =
+        if (containmentType.contains(4L)) rawRecord.getOptional("de_property_fence_other")
+        else None,
+      dePropertyDrinkingWaterBowl = drinkingWaterSources.map(_.contains("1")),
+      dePropertyDrinkingWaterHose = drinkingWaterSources.map(_.contains("2")),
+      dePropertyDrinkingWaterPuddles = drinkingWaterSources.map(_.contains("3")),
+      dePropertyDrinkingWaterUnknown = drinkingWaterSources.map(_.contains("99")),
+      dePropertyDrinkingWaterOther = drinkingWaterOther,
+      dePropertyDrinkingWaterOtherDescription =
+        if (drinkingWaterOther.contains(true)) rawRecord.getOptional("de_outside_water_other")
+        else None,
+      dePropertyWeedControlFrequency =
+        if (weedControl.contains(1L)) rawRecord.getOptionalNumber("de_yard_weed_ctl_freq")
+        else weedControl,
+      dePropertyPestControlFrequency =
+        if (pestControl.contains(1L)) rawRecord.getOptionalNumber("de_yard_pest_ctl_freq")
+        else pestControl
+    )
+  }
+
+  /**
+    * Parse neighborhood-related fields out of a raw RedCap record,
+    * injecting them into a partially-modeled dog record.
+    */
+  def mapNeighborhood(
+    rawRecord: RawRecord,
+    dog: HlesDogResidentialEnvironment
+  ): HlesDogResidentialEnvironment = {
+    val animalsInteract = rawRecord.getOptionalBoolean("de_animal_interact")
+    val humansInteract = rawRecord.getOptionalBoolean("de_human_interact")
+    dog.copy(
+      deTrafficNoiseInHomeFrequency = rawRecord.getOptionalNumber("de_traffic_noise_house"),
+      deTrafficNoiseInPropertyFrequency = rawRecord.getOptionalNumber("de_traffic_noise_yard"),
+      deNeighborhoodHasSidewalks = rawRecord.getOptionalNumber("de_sidewalk_yn"),
+      deNeighborhoodHasParks = rawRecord.getOptionalBoolean("de_parks_near"),
+      deInteractsWithNeighborhoodAnimals = animalsInteract,
+      deInteractsWithNeighborhoodAnimalsWithoutOwner =
+        if (animalsInteract.contains(true))
+          rawRecord.getOptionalBoolean("de_animal_interact_present").map(!_)
+        else None,
+      deInteractsWithNeighborhoodHumans = humansInteract,
+      deInteractsWithNeighborhoodHumansWithoutOwner =
+        if (humansInteract.contains(true))
+          rawRecord.getOptionalBoolean("de_human_interact_present").map(!_)
+        else None
+    )
+  }
+}

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -37,9 +37,9 @@ object ResidentialEnvironmentTransformations {
       val currentResidenceCount = if (secondaryHome.head) 2 else 1
       val totalResidenceCount = pastResidenceCount.head + currentResidenceCount
       val pastZipCount =
-        if (totalResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
+        if (pastResidenceCount.head > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
       val pastCountryCount =
-        if (totalResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
+        if (pastResidenceCount.head > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
 
       dog.copy(
         deLifetimeResidenceCount = Some(totalResidenceCount),
@@ -155,10 +155,9 @@ object ResidentialEnvironmentTransformations {
   ): HlesDogResidentialEnvironment = {
     val source = rawRecord.getOptionalNumber("de_water_source")
     val knownPipes = rawRecord.getOptionalBoolean("de_pipe_yn")
-    val pipeType = knownPipes match {
-      case Some(false) => Some(99L) // unknown type
-      case Some(true)  => rawRecord.getOptionalNumber("de_pipe_type")
-      case None        => None
+    val pipeType = knownPipes.flatMap {
+      case true  => rawRecord.getOptionalNumber("de_pipe_type")
+      case false => Some(99L) // unknown type
     }
     dog.copy(
       deDrinkingWaterSource = source,

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -34,7 +34,7 @@ object ResidentialEnvironmentTransformations {
     val secondaryHome = rawRecord.getOptionalBoolean("oc_address2_yn")
     val pastResidenceCount = rawRecord.getOptionalNumber("de_home_nbr")
     val currentResidenceCount = secondaryHome.flatMap {
-      case true => Some(2L)
+      case true  => Some(2L)
       case false => Some(1L)
     }
     if (pastResidenceCount.isDefined) {

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -35,55 +35,57 @@ object ResidentialEnvironmentTransformations {
       case true  => 2L
       case false => 1L
     }
-    rawRecord.getOptionalNumber("de_home_nbr").fold(dog) { pastResidenceCount =>
-      val pastZipCount =
-        if (pastResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
-      val pastCountryCount =
-        if (pastResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
+    rawRecord
+      .getOptionalNumber("de_home_nbr")
+      .fold(dog.copy(deLifetimeResidenceCount = currentResidenceCount)) { pastResidenceCount =>
+        val pastZipCount =
+          if (pastResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
+        val pastCountryCount =
+          if (pastResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
 
-      dog.copy(
-        deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
-        dePastResidenceZipCount = Some(pastZipCount),
-        dePastResidenceZip1 = if (pastZipCount > 1) {
-          rawRecord.getOptional("de_zip_01")
-        } else {
-          rawRecord.getOptional("de_zip_01_only")
-        },
-        dePastResidenceZip2 = if (pastZipCount > 1) rawRecord.getOptional("de_zip_02") else None,
-        dePastResidenceZip3 = if (pastZipCount > 2) rawRecord.getOptional("de_zip_03") else None,
-        dePastResidenceZip4 = if (pastZipCount > 3) rawRecord.getOptional("de_zip_04") else None,
-        dePastResidenceZip5 = if (pastZipCount > 4) rawRecord.getOptional("de_zip_05") else None,
-        dePastResidenceZip6 = if (pastZipCount > 5) rawRecord.getOptional("de_zip_06") else None,
-        dePastResidenceZip7 = if (pastZipCount > 6) rawRecord.getOptional("de_zip_07") else None,
-        dePastResidenceZip8 = if (pastZipCount > 7) rawRecord.getOptional("de_zip_08") else None,
-        dePastResidenceZip9 = if (pastZipCount > 8) rawRecord.getOptional("de_zip_09") else None,
-        dePastResidenceZip10 = if (pastZipCount > 9) rawRecord.getOptional("de_zip_10") else None,
-        dePastResidenceCountryCount = Some(pastCountryCount),
-        dePastResidenceCountry1 = if (pastCountryCount > 1) {
-          rawRecord.getOptional("de_country_01")
-        } else {
-          rawRecord.getOptional("de_country_01_only")
-        },
-        dePastResidenceCountry2 =
-          if (pastCountryCount > 1) rawRecord.getOptional("de_country_02") else None,
-        dePastResidenceCountry3 =
-          if (pastCountryCount > 2) rawRecord.getOptional("de_country_03") else None,
-        dePastResidenceCountry4 =
-          if (pastCountryCount > 3) rawRecord.getOptional("de_country_04") else None,
-        dePastResidenceCountry5 =
-          if (pastCountryCount > 4) rawRecord.getOptional("de_country_05") else None,
-        dePastResidenceCountry6 =
-          if (pastCountryCount > 5) rawRecord.getOptional("de_country_06") else None,
-        dePastResidenceCountry7 =
-          if (pastCountryCount > 6) rawRecord.getOptional("de_country_07") else None,
-        dePastResidenceCountry8 =
-          if (pastCountryCount > 7) rawRecord.getOptional("de_country_08") else None,
-        dePastResidenceCountry9 =
-          if (pastCountryCount > 8) rawRecord.getOptional("de_country_09") else None,
-        dePastResidenceCountry10 =
-          if (pastCountryCount > 9) rawRecord.getOptional("de_country_10") else None
-      )
-    }
+        dog.copy(
+          deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
+          dePastResidenceZipCount = Some(pastZipCount),
+          dePastResidenceZip1 = if (pastZipCount > 1) {
+            rawRecord.getOptional("de_zip_01")
+          } else {
+            rawRecord.getOptional("de_zip_01_only")
+          },
+          dePastResidenceZip2 = if (pastZipCount > 1) rawRecord.getOptional("de_zip_02") else None,
+          dePastResidenceZip3 = if (pastZipCount > 2) rawRecord.getOptional("de_zip_03") else None,
+          dePastResidenceZip4 = if (pastZipCount > 3) rawRecord.getOptional("de_zip_04") else None,
+          dePastResidenceZip5 = if (pastZipCount > 4) rawRecord.getOptional("de_zip_05") else None,
+          dePastResidenceZip6 = if (pastZipCount > 5) rawRecord.getOptional("de_zip_06") else None,
+          dePastResidenceZip7 = if (pastZipCount > 6) rawRecord.getOptional("de_zip_07") else None,
+          dePastResidenceZip8 = if (pastZipCount > 7) rawRecord.getOptional("de_zip_08") else None,
+          dePastResidenceZip9 = if (pastZipCount > 8) rawRecord.getOptional("de_zip_09") else None,
+          dePastResidenceZip10 = if (pastZipCount > 9) rawRecord.getOptional("de_zip_10") else None,
+          dePastResidenceCountryCount = Some(pastCountryCount),
+          dePastResidenceCountry1 = if (pastCountryCount > 1) {
+            rawRecord.getOptional("de_country_01")
+          } else {
+            rawRecord.getOptional("de_country_01_only")
+          },
+          dePastResidenceCountry2 =
+            if (pastCountryCount > 1) rawRecord.getOptional("de_country_02") else None,
+          dePastResidenceCountry3 =
+            if (pastCountryCount > 2) rawRecord.getOptional("de_country_03") else None,
+          dePastResidenceCountry4 =
+            if (pastCountryCount > 3) rawRecord.getOptional("de_country_04") else None,
+          dePastResidenceCountry5 =
+            if (pastCountryCount > 4) rawRecord.getOptional("de_country_05") else None,
+          dePastResidenceCountry6 =
+            if (pastCountryCount > 5) rawRecord.getOptional("de_country_06") else None,
+          dePastResidenceCountry7 =
+            if (pastCountryCount > 6) rawRecord.getOptional("de_country_07") else None,
+          dePastResidenceCountry8 =
+            if (pastCountryCount > 7) rawRecord.getOptional("de_country_08") else None,
+          dePastResidenceCountry9 =
+            if (pastCountryCount > 8) rawRecord.getOptional("de_country_09") else None,
+          dePastResidenceCountry10 =
+            if (pastCountryCount > 9) rawRecord.getOptional("de_country_10") else None
+        )
+      }
   }
 
   /**

--- a/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hle-survey/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -33,9 +33,12 @@ object ResidentialEnvironmentTransformations {
   ): HlesDogResidentialEnvironment = {
     val secondaryHome = rawRecord.getOptionalBoolean("oc_address2_yn")
     val pastResidenceCount = rawRecord.getOptionalNumber("de_home_nbr")
-    if (secondaryHome.isDefined && pastResidenceCount.isDefined) {
-      val currentResidenceCount = if (secondaryHome.head) 2 else 1
-      val totalResidenceCount = pastResidenceCount.head + currentResidenceCount
+    val currentResidenceCount = secondaryHome.flatMap {
+      case true => Some(2L)
+      case false => Some(1L)
+    }
+    if (pastResidenceCount.isDefined) {
+      val totalResidenceCount = pastResidenceCount.head + currentResidenceCount.getOrElse(0L)
       val pastZipCount =
         if (pastResidenceCount.head > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
       val pastCountryCount =

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -21,6 +21,7 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
       hlesDogDiet = Some(HlesDogDiet.init()),
       hlesDogHealthSummary = Some(HlesDogHealthSummary.init()),
       hlesDogPhysicalActivity = Some(HlesDogPhysicalActivity.init()),
+      hlesDogResidentialEnvironment = Some(HlesDogResidentialEnvironment.init()),
       hlesDogMedsPreventatives = Some(HlesDogMedsPreventatives.init()),
       hlesDogFutureStudies = Some(HlesDogFutureStudies.init())
     )

--- a/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hle-survey/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -1,0 +1,465 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.RawRecord
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ResidentialEnvironmentTransformationsSpec
+    extends AnyFlatSpec
+    with Matchers
+    with OptionValues {
+  behavior of "ResidentialEnvironmentTransformations"
+
+  it should "map all past-residence-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_home_nbr" -> Array("10"),
+      "oc_address2_yn" -> Array("1"),
+      "de_zip_nbr" -> Array("10"),
+      "de_zip_01_only" -> Array("this should be ignored"),
+      "de_zip_01" -> Array("11111"),
+      "de_zip_02" -> Array("22222"),
+      "de_zip_03" -> Array("33333"),
+      "de_zip_04" -> Array("44444"),
+      "de_zip_05" -> Array("55555"),
+      "de_zip_06" -> Array("66666"),
+      "de_zip_07" -> Array("77777"),
+      "de_zip_08" -> Array("88888"),
+      "de_zip_09" -> Array("99999"),
+      "de_zip_10" -> Array("10101"),
+      "de_country_nbr" -> Array("10"),
+      "de_country_01_only" -> Array("this should be ignored too"),
+      "de_country_01" -> Array("country1"),
+      "de_country_02" -> Array("country2"),
+      "de_country_03" -> Array("country3"),
+      "de_country_04" -> Array("country4"),
+      "de_country_05" -> Array("country5"),
+      "de_country_06" -> Array("country6"),
+      "de_country_07" -> Array("country7"),
+      "de_country_08" -> Array("country8"),
+      "de_country_09" -> Array("country9"),
+      "de_country_10" -> Array("country10")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deLifetimeResidenceCount.value shouldBe 12
+    output.dePastResidenceZipCount.value shouldBe 10
+    output.dePastResidenceZip1.value shouldBe "11111"
+    output.dePastResidenceZip2.value shouldBe "22222"
+    output.dePastResidenceZip3.value shouldBe "33333"
+    output.dePastResidenceZip4.value shouldBe "44444"
+    output.dePastResidenceZip5.value shouldBe "55555"
+    output.dePastResidenceZip6.value shouldBe "66666"
+    output.dePastResidenceZip7.value shouldBe "77777"
+    output.dePastResidenceZip8.value shouldBe "88888"
+    output.dePastResidenceZip9.value shouldBe "99999"
+    output.dePastResidenceZip10.value shouldBe "10101"
+    output.dePastResidenceCountryCount.value shouldBe 10
+    output.dePastResidenceCountry1.value shouldBe "country1"
+    output.dePastResidenceCountry2.value shouldBe "country2"
+    output.dePastResidenceCountry3.value shouldBe "country3"
+    output.dePastResidenceCountry4.value shouldBe "country4"
+    output.dePastResidenceCountry5.value shouldBe "country5"
+    output.dePastResidenceCountry6.value shouldBe "country6"
+    output.dePastResidenceCountry7.value shouldBe "country7"
+    output.dePastResidenceCountry8.value shouldBe "country8"
+    output.dePastResidenceCountry9.value shouldBe "country9"
+    output.dePastResidenceCountry10.value shouldBe "country10"
+  }
+
+  it should "map past-residence-related fields where there is a single past and current home" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_home_nbr" -> Array("1"),
+      "oc_address2_yn" -> Array("0"),
+      "de_zip_nbr" -> Array("1"),
+      "de_zip_01_only" -> Array("12345"),
+      "de_zip_01" -> Array("ignoredZip1"),
+      "de_zip_01" -> Array("ignoredZip2"),
+      "de_country_nbr" -> Array("1"),
+      "de_country_01_only" -> Array("USA!"),
+      "de_country_01" -> Array("this should be ignored"),
+      "de_country_02" -> Array("IgnoredCountry")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deLifetimeResidenceCount.value shouldBe 2
+    output.dePastResidenceZipCount.value shouldBe 1
+    output.dePastResidenceZip1.value shouldBe "12345"
+    output.dePastResidenceZip2 shouldBe None
+    output.dePastResidenceCountryCount.value shouldBe 1
+    output.dePastResidenceCountry1.value shouldBe "USA!"
+    output.dePastResidenceCountry2 shouldBe None
+  }
+
+  it should "map all home-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_type_area" -> Array("2000"),
+      "de_type_home" -> Array("2"),
+      "he_type_home_other" -> Array("something else"),
+      "de_home_age" -> Array("75"),
+      "de_home_lived_years" -> Array("10"),
+      "de_home_area" -> Array("1000")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deHomeAreaType.value shouldBe 2000
+    output.deHomeType.value shouldBe 2
+    output.deHomeTypeOtherDescription.value shouldBe "something else"
+    output.deHomeConstructionDecade.value shouldBe 75
+    output.deHomeYearsLivedIn.value shouldBe 10
+    output.deHomeSquareFootage.value shouldBe 1000
+  }
+
+  it should "map all heating-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_primary_heat" -> Array("98"),
+      "de_primary_heat_other" -> Array("a large campfire"),
+      "de_secondary_heat_yn" -> Array("1"),
+      "de_secondary_heat" -> Array("98"),
+      "de_secondary_heat_other" -> Array("a small campfire"),
+      "de_primary_stove" -> Array("98"),
+      "de_primary_stove_other" -> Array("a moderately sized campfire"),
+      "de_secondary_stove_yn" -> Array("1"),
+      "de_secondary_stove" -> Array("98"),
+      "de_secondary_stove_other" -> Array("a grill")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.dePrimaryHeatFuel.value shouldBe 98L
+    output.dePrimaryHeatFuelOtherDescription.value shouldBe "a large campfire"
+    output.deSecondaryHeatFuelUsed.value shouldBe 1L
+    output.deSecondaryHeatFuel.value shouldBe 98L
+    output.deSecondaryHeatFuelOtherDescription.value shouldBe "a small campfire"
+    output.dePrimaryStoveFuel.value shouldBe 98L
+    output.dePrimaryStoveFuelOtherDescription.value shouldBe "a moderately sized campfire"
+    output.deSecondaryStoveFuelUsed.value shouldBe 1L
+    output.deSecondaryStoveFuel.value shouldBe 98L
+    output.deSecondaryStoveFuelOtherDescription.value shouldBe "a grill"
+  }
+
+  it should "map heating-related fields where there is no secondary heat or stove and no 'other' values selected" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_primary_heat" -> Array("1"),
+      "de_primary_heat_other" -> Array("should be ignored"),
+      "de_secondary_heat_yn" -> Array("0"),
+      "de_secondary_heat" -> Array("98"),
+      "de_secondary_heat_other" -> Array("should be ignored"),
+      "de_primary_stove" -> Array("3"),
+      "de_primary_stove_other" -> Array("should be ignored"),
+      "de_secondary_stove_yn" -> Array("0"),
+      "de_secondary_stove" -> Array("98"),
+      "de_secondary_stove_other" -> Array("should be ignored")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.dePrimaryHeatFuel.value shouldBe 1L
+    output.dePrimaryHeatFuelOtherDescription shouldBe None
+    output.deSecondaryHeatFuelUsed.value shouldBe 0L
+    output.deSecondaryHeatFuel shouldBe None
+    output.deSecondaryHeatFuelOtherDescription shouldBe None
+    output.dePrimaryStoveFuel.value shouldBe 3L
+    output.dePrimaryStoveFuelOtherDescription shouldBe None
+    output.deSecondaryStoveFuelUsed.value shouldBe 0L
+    output.deSecondaryStoveFuel shouldBe None
+    output.deSecondaryStoveFuelOtherDescription shouldBe None
+  }
+
+  it should "map all drinking-water-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_water_source" -> Array("98"),
+      "de_water_source_other" -> Array("puddles"),
+      "de_water_filter_yn" -> Array("1"),
+      "de_pipe_yn" -> Array("1"),
+      "de_pipe_type" -> Array("98"),
+      "de_pipe_type_other" -> Array("ceramic")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deDrinkingWaterSource.value shouldBe 98L
+    output.deDrinkingWaterSourceOtherDescription.value shouldBe "puddles"
+    output.deDrinkingWaterIsFiltered.value shouldBe 1L
+    output.dePipeType.value shouldBe 98L
+    output.dePipeTypeOtherDescription.value shouldBe "ceramic"
+  }
+
+  it should "map drinking-water-related fields where pipe type is unknown" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_water_source" -> Array("3"),
+      "de_water_source_other" -> Array("ignore me"),
+      "de_water_filter_yn" -> Array("0"),
+      "de_pipe_yn" -> Array("0"),
+      "de_pipe_type" -> Array("4"),
+      "de_pipe_type_other" -> Array("ignore me")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deDrinkingWaterSource.value shouldBe 3L
+    output.deDrinkingWaterSourceOtherDescription shouldBe None
+    output.deDrinkingWaterIsFiltered.value shouldBe 0L
+    output.dePipeType.value shouldBe 99L
+    output.dePipeTypeOtherDescription shouldBe None
+  }
+
+  it should "map all toxin-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_2nd_hand_smoke_amt" -> Array("1"),
+      "de_central_ac" -> Array("0"),
+      "de_room_ac" -> Array("99"),
+      "de_central_heat" -> Array("1"),
+      "de_asbestos" -> Array("0"),
+      "de_radon" -> Array("99"),
+      "de_lead" -> Array("1"),
+      "de_mothball" -> Array("0"),
+      "de_incense" -> Array("99"),
+      "de_air_freshener" -> Array("1"),
+      "de_air_cleaner" -> Array("0"),
+      "de_hepa" -> Array("99"),
+      "de_wood_burning" -> Array("1"),
+      "de_gas_fireplace" -> Array("1"),
+      "de_wood_fireplace_lit" -> Array("5"),
+      "de_gas_fireplace_lit" -> Array("6")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deSecondHandSmokeHoursPerDay.value shouldBe 1L
+    output.deCentralAirConditioningPresent.value shouldBe 0L
+    output.deRoomOrWindowAirConditioningPresent.value shouldBe 99L
+    output.deCentralHeatPresent.value shouldBe 1L
+    output.deAsbestosPresent.value shouldBe 0L
+    output.deRadonPresent.value shouldBe 99L
+    output.deLeadPresent.value shouldBe 1L
+    output.deMothballPresent.value shouldBe 0L
+    output.deIncensePresent.value shouldBe 99L
+    output.deAirFreshenerPresent.value shouldBe 1L
+    output.deAirCleanerPresent.value shouldBe 0L
+    output.deHepaPresent.value shouldBe 99L
+    output.deWoodFireplacePresent.value shouldBe 1L
+    output.deGasFireplacePresent.value shouldBe 1L
+    output.deWoodFireplaceLightingsPerWeek.value shouldBe 5L
+    output.deGasFireplaceLightingsPerWeek.value shouldBe 6L
+  }
+
+  it should "map all flooring-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_floor_wood_yn" -> Array("1"),
+      "de_floor_wood_freq" -> Array("0"),
+      "de_floor_carpet_yn" -> Array("1"),
+      "de_floor_carpet_freq" -> Array("1"),
+      "de_floor_concrete_yn" -> Array("1"),
+      "de_floor_concrete_freq" -> Array("2"),
+      "de_floor_tile_yn" -> Array("1"),
+      "de_floor_tile_freq" -> Array("3"),
+      "de_floor_linoleum_yn" -> Array("1"),
+      "de_floor_linoleum_freq" -> Array("0"),
+      "de_floor_laminate_yn" -> Array("1"),
+      "de_floor_laminate_freq" -> Array("1"),
+      "de_floor_other_yn" -> Array("1"),
+      "de_floor_other" -> Array("pool noodles"),
+      "de_floor_other_freq" -> Array("2"),
+      "de_stairs" -> Array("1"),
+      "de_stairs_nbr" -> Array("3")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deFloorTypesWood.value shouldBe true
+    output.deFloorFrequencyOnWood.value shouldBe 0L
+    output.deFloorTypesCarpet.value shouldBe true
+    output.deFloorFrequencyOnCarpet.value shouldBe 1L
+    output.deFloorTypesConcrete.value shouldBe true
+    output.deFloorFrequencyOnConcrete.value shouldBe 2L
+    output.deFloorTypesTile.value shouldBe true
+    output.deFloorFrequencyOnTile.value shouldBe 3L
+    output.deFloorTypesLinoleum.value shouldBe true
+    output.deFloorFrequencyOnLinoleum.value shouldBe 0L
+    output.deFloorTypesLaminate.value shouldBe true
+    output.deFloorFrequencyOnLaminate.value shouldBe 1L
+    output.deFloorTypesOther.value shouldBe true
+    output.deFloorTypesOtherDescription.value shouldBe "pool noodles"
+    output.deFloorFrequencyOnOther.value shouldBe 2L
+    output.deStairsInHome.value shouldBe true
+    output.deStairsAvgFlightsPerDay.value shouldBe 3L
+  }
+
+  it should "map flooring-related fields where no flooring types are selected" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_floor_wood_yn" -> Array("0"),
+      "de_floor_wood_freq" -> Array("0"),
+      "de_floor_carpet_yn" -> Array("0"),
+      "de_floor_carpet_freq" -> Array("0"),
+      "de_floor_concrete_yn" -> Array("0"),
+      "de_floor_concrete_freq" -> Array("0"),
+      "de_floor_tile_yn" -> Array("0"),
+      "de_floor_tile_freq" -> Array("0"),
+      "de_floor_linoleum_yn" -> Array("0"),
+      "de_floor_linoleum_freq" -> Array("0"),
+      "de_floor_laminate_yn" -> Array("0"),
+      "de_floor_laminate_freq" -> Array("0"),
+      "de_floor_other_yn" -> Array("0"),
+      "de_floor_other" -> Array("should be ignored"),
+      "de_floor_other_freq" -> Array("0"),
+      "de_stairs" -> Array("0"),
+      "de_stairs_nbr" -> Array("0")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deFloorTypesWood.value shouldBe false
+    output.deFloorFrequencyOnWood shouldBe None
+    output.deFloorTypesCarpet.value shouldBe false
+    output.deFloorFrequencyOnCarpet shouldBe None
+    output.deFloorTypesConcrete.value shouldBe false
+    output.deFloorFrequencyOnConcrete shouldBe None
+    output.deFloorTypesTile.value shouldBe false
+    output.deFloorFrequencyOnTile shouldBe None
+    output.deFloorTypesLinoleum.value shouldBe false
+    output.deFloorFrequencyOnLinoleum shouldBe None
+    output.deFloorTypesLaminate.value shouldBe false
+    output.deFloorFrequencyOnLaminate shouldBe None
+    output.deFloorTypesOther.value shouldBe false
+    output.deFloorTypesOtherDescription shouldBe None
+    output.deFloorFrequencyOnOther shouldBe None
+    output.deStairsInHome.value shouldBe false
+    output.deStairsAvgFlightsPerDay shouldBe None
+  }
+
+  it should "map all property-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_property_size" -> Array("2"),
+      "de_property_access_yn" -> Array("1"),
+      "de_property_access" -> Array("2"),
+      "de_property_fence_yn" -> Array("4"),
+      "de_property_fence_other" -> Array("a different fence"),
+      "de_outside_water" -> Array("1", "3", "98"),
+      "de_outside_water_other" -> Array("a river"),
+      "de_yard_weed_ctl_yn" -> Array("1"),
+      "de_yard_weed_ctl_freq" -> Array("5"),
+      "de_yard_pest_ctl_yn" -> Array("1"),
+      "de_yard_pest_ctl_freq" -> Array("6")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.dePropertyArea.value shouldBe 2L
+    output.dePropertyAccessible.value shouldBe true
+    output.dePropertyAreaAccessible.value shouldBe 2L
+    output.dePropertyContainmentType.value shouldBe 4L
+    output.dePropertyContainmentTypeOtherDescription.value shouldBe "a different fence"
+    output.dePropertyDrinkingWaterBowl.value shouldBe true
+    output.dePropertyDrinkingWaterHose.value shouldBe false
+    output.dePropertyDrinkingWaterPuddles.value shouldBe true
+    output.dePropertyDrinkingWaterUnknown.value shouldBe false
+    output.dePropertyDrinkingWaterOther.value shouldBe true
+    output.dePropertyDrinkingWaterOtherDescription.value shouldBe "a river"
+    output.dePropertyWeedControlFrequency.value shouldBe 5L
+    output.dePropertyPestControlFrequency.value shouldBe 6L
+  }
+
+  it should "map property-related fields where there are no access, no weeds, and no pests" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_property_size" -> Array("3"),
+      "de_property_access_yn" -> Array("0"),
+      "de_property_access" -> Array("2"),
+      "de_property_fence_yn" -> Array("4"),
+      "de_property_fence_other" -> Array("ignore this"),
+      "de_outside_water" -> Array("2", "99"),
+      "de_outside_water_other" -> Array("ignore this"),
+      "de_yard_weed_ctl_yn" -> Array("0"),
+      "de_yard_weed_ctl_freq" -> Array("5"),
+      "de_yard_pest_ctl_yn" -> Array("0"),
+      "de_yard_pest_ctl_freq" -> Array("6")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.dePropertyArea.value shouldBe 3L
+    output.dePropertyAccessible.value shouldBe false
+    output.dePropertyAreaAccessible shouldBe None
+    output.dePropertyContainmentType shouldBe None
+    output.dePropertyContainmentTypeOtherDescription shouldBe None
+    output.dePropertyDrinkingWaterBowl.value shouldBe false
+    output.dePropertyDrinkingWaterHose.value shouldBe true
+    output.dePropertyDrinkingWaterPuddles.value shouldBe false
+    output.dePropertyDrinkingWaterUnknown.value shouldBe true
+    output.dePropertyDrinkingWaterOther.value shouldBe false
+    output.dePropertyDrinkingWaterOtherDescription shouldBe None
+    output.dePropertyWeedControlFrequency.value shouldBe 0
+    output.dePropertyPestControlFrequency.value shouldBe 0
+  }
+
+  it should "map all neighborhood-related fields" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_traffic_noise_house" -> Array("1"),
+      "de_traffic_noise_yard" -> Array("2"),
+      "de_sidewalk_yn" -> Array("3"),
+      "de_parks_near" -> Array("0"),
+      "de_animal_interact" -> Array("1"),
+      "de_animal_interact_present" -> Array("1"),
+      "de_human_interact" -> Array("1"),
+      "de_human_interact_present" -> Array("1")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deTrafficNoiseInHomeFrequency.value shouldBe 1L
+    output.deTrafficNoiseInPropertyFrequency.value shouldBe 2L
+    output.deNeighborhoodHasSidewalks.value shouldBe 3L
+    output.deNeighborhoodHasParks.value shouldBe false
+    output.deInteractsWithNeighborhoodAnimals.value shouldBe true
+    output.deInteractsWithNeighborhoodAnimalsWithoutOwner.value shouldBe false
+    output.deInteractsWithNeighborhoodHumans.value shouldBe true
+    output.deInteractsWithNeighborhoodHumansWithoutOwner.value shouldBe false
+  }
+
+  it should "map neighborhood-related fields where there are no neighborhood animal interactions" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_animal_interact" -> Array("0"),
+      "de_animal_interact_present" -> Array("1"),
+      "de_human_interact" -> Array("0"),
+      "de_human_interact_present" -> Array("1")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deInteractsWithNeighborhoodAnimals.value shouldBe false
+    output.deInteractsWithNeighborhoodAnimalsWithoutOwner shouldBe None
+    output.deInteractsWithNeighborhoodHumans.value shouldBe false
+    output.deInteractsWithNeighborhoodHumansWithoutOwner shouldBe None
+  }
+}

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -1,0 +1,397 @@
+{
+  "name": "hles_dog_residential_environment",
+  "columns": [
+    {
+      "name": "de_lifetime_residence_count",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_past_residence_zip_count",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_past_residence_zip_1",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_2",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_3",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_4",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_5",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_6",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_7",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_8",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_9",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_zip_10",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_count",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_past_residence_country_1",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_2",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_3",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_4",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_5",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_6",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_7",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_8",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_9",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country_10",
+      "datatype": "string"
+    },
+    {
+      "name": "de_home_area_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_home_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_home_type_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_home_construction_decade",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_home_years_lived_in",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_home_square_footage",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_primary_heat_fuel",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_primary_heat_fuel_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_secondary_heat_fuel_used",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_secondary_heat_fuel",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_secondary_heat_fuel_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_primary_stove_fuel",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_primary_stove_fuel_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_secondary_stove_fuel_used",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_secondary_stove_fuel",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_secondary_stove_fuel_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_drinking_water_source",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_drinking_water_source_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_drinking_water_is_filtered",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_pipe_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_pipe_type_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_second_hand_smoke_hours_per_day",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_central_air_conditioning_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_room_or_window_air_conditioning_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_central_heat_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_asbestos_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_radon_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_lead_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_mothball_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_incense_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_air_freshener_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_air_cleaner_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_hepa_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_wood_fireplace_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_gas_fireplace_present",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_wood_fireplace_lightings_per_week",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_gas_fireplace_lightings_per_week",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_wood",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_wood",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_carpet",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_carpet",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_concrete",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_concrete",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_tile",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_tile",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_linoleum",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_linoleum",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_laminate",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_frequency_on_laminate",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_floor_types_other",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_floor_types_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_floor_frequency_on_other",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_stairs_in_home",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_stairs_avg_flights_per_day",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_property_area",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_property_accessible",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_area_accessible",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_property_containment_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_property_containment_type_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_property_drinking_water_bowl",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_drinking_water_hose",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_drinking_water_puddles",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_drinking_water_unknown",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_drinking_water_other",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_property_drinking_water_other_description",
+      "datatype": "string"
+    },
+    {
+      "name": "de_property_weed_control_frequency",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_property_pest_control_frequency",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_traffic_noise_in_home_frequency",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_traffic_noise_in_property_frequency",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_neighborhood_has_sidewalks",
+      "datatype": "integer"
+    },
+    {
+      "name": "de_neighborhood_has_parks",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_interacts_with_neighborhood_animals",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_interacts_with_neighborhood_animals_without_owner",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_interacts_with_neighborhood_humans",
+      "datatype": "boolean"
+    },
+    {
+      "name": "de_interacts_with_neighborhood_humans_without_owner",
+      "datatype": "boolean"
+    }
+  ]
+}

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -10,43 +10,43 @@
       "datatype": "integer"
     },
     {
-      "name": "de_past_residence_zip_1",
+      "name": "de_past_residence_zip1",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_2",
+      "name": "de_past_residence_zip2",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_3",
+      "name": "de_past_residence_zip3",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_4",
+      "name": "de_past_residence_zip4",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_5",
+      "name": "de_past_residence_zip5",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_6",
+      "name": "de_past_residence_zip6",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_7",
+      "name": "de_past_residence_zip7",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_8",
+      "name": "de_past_residence_zip8",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_9",
+      "name": "de_past_residence_zip9",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_zip_10",
+      "name": "de_past_residence_zip10",
       "datatype": "string"
     },
     {
@@ -54,43 +54,43 @@
       "datatype": "integer"
     },
     {
-      "name": "de_past_residence_country_1",
+      "name": "de_past_residence_country1",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_2",
+      "name": "de_past_residence_country2",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_3",
+      "name": "de_past_residence_country3",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_4",
+      "name": "de_past_residence_country4",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_5",
+      "name": "de_past_residence_country5",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_6",
+      "name": "de_past_residence_country6",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_7",
+      "name": "de_past_residence_country7",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_8",
+      "name": "de_past_residence_country8",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_9",
+      "name": "de_past_residence_country9",
       "datatype": "string"
     },
     {
-      "name": "de_past_residence_country_10",
+      "name": "de_past_residence_country10",
       "datatype": "string"
     },
     {

--- a/schema/src/main/jade-tables/hles_dog.table.json
+++ b/schema/src/main/jade-tables/hles_dog.table.json
@@ -23,6 +23,7 @@
     "hles_dog_demographics",
     "hles_dog_residences",
     "hles_dog_physical_activity",
+    "hles_dog_residential_environment",
     "hles_dog_behavior",
     "hles_dog_diet",
     "hles_dog_meds_preventatives",


### PR DESCRIPTION
Transforming about half of the ~200 dog environment columns. For reference, the columns in this PR are the `de_` columns which are highlighted in green on the [schema mapping sheet](https://docs.google.com/spreadsheets/d/1QqWzkVtsUUjOvOqCJEA8R6YcfcAq87MzYvMLnMQBa58/edit?usp=sharing). 

These changes had originally been a part of a [larger branch](https://github.com/DataBiosphere/dog-aging-ingest/compare/SW-DSPDC-1058-map-environment-fields), but I separated them out here for the sake of smaller PRs. 