### PR TITLE
Extend tsv output script for manual DAP updates

### DIFF
--- a/hack/convert-output-to-tsv.py
+++ b/hack/convert-output-to-tsv.py
@@ -24,6 +24,7 @@ def printd(x):
         print("[DEBUG] "+x)
     else:
         pass
+
 # Process the known (hardcoded) tables
 for table_name in table_names:
     print ("\nPROCESSING {0}".format(table_name))
@@ -87,6 +88,7 @@ for table_name in table_names:
     column_set.remove(entity_name)
     sorted_column_set = sorted(list(column_set))    
     sorted_column_set.insert(0, entity_name)
+
     # provide some stats
     col_count = len(sorted_column_set)
     print("...%s contains %s rows and %s columns" % 
@@ -135,7 +137,11 @@ for table_name in table_names:
                         # if a whitelisted col exists in this row
                         if (col in dict(row).keys()):
                             # add the col to the split list
-                            split_row_dict[col] = (dict(row).get(col))
+                            # clean up whitespace
+                            try:
+                                split_row_dict[col] = (dict(row).get(col)).replace('\r\n',' ').strip()
+                            except AttributeError:
+                                split_row_dict[col] = (dict(row).get(col))
                         else:
                             pass
                     # add the row to the list of rows for this

--- a/hack/convert-output-to-tsv.py
+++ b/hack/convert-output-to-tsv.py
@@ -2,38 +2,144 @@ import json
 import csv
 from os import listdir
 import sys
+from math import ceil
 
+# CLI args
 if (len(sys.argv) < 3):
-    print "Please provide the input directory and output directory as arguments!"
+    printd("Please provide the input directory and output directory as arguments!")
 
 input_dir = sys.argv[1]
 output_dir = sys.argv[2]
-table_names = listdir(input_dir) 
+# optional debug arg
+try:
+    debug = sys.argv[3]
+except IndexError:
+    debug = None
+
+table_names = ['hles_cancer_condition', 'hles_dog', 'hles_health_condition', 'hles_owner']
 pk_prefix = 'entity:'
 
+# debug printer
+def printd(x):
+    if debug:
+        print("[DEBUG] "+x)
+    else:
+        pass
+
+
 for table_name in table_names:
+    print ("\nPROCESSING {0}".format(table_name))
     # get the set of files in the directory
-    full_input_directory = input_dir + table_name + '/'
-    input_files = listdir(full_input_directory)
-    output_name = table_name[5:] # remove 'hles_' from the file name
+    full_input_directory = input_dir + '/' + table_name
+    # ingore hidden files and sort files alphabetically
+    input_files = sorted([f for f in listdir(full_input_directory) if not f.startswith('.')])
 
     column_set = set()
     row_list = []
-    # read json data
+
+    # read json data    
     for json_file_name in input_files:
-        with open(full_input_directory + json_file_name, 'r') as json_file:
+        print("...Opening {0}".format(full_input_directory+'/'+json_file_name))
+        with open(full_input_directory + '/' + json_file_name, 'r') as json_file:
+            row_count = 0
             for jsonObj in json_file:
+                row_count += 1
                 row = json.loads(jsonObj)
                 # rename primary key column to the format 'entity:{entity name}_id'
-                pk_name = output_name + '_id'
-                row[pk_prefix + pk_name] = row.pop(pk_name)
-                # store data
-                column_set.update(row.keys())
-                row_list.append(row)
+                # pop existing primary keys out and push them back in
+                if (table_name == "hles_owner" or table_name == "hles_dog"):
+                    # remove 'hles_' from the table_name
+                    pk_name = table_name[5:] + '_id'
+                    entity_name = pk_prefix + pk_name
+                    row[entity_name] = row.pop(pk_name)
+                    # store data
+                    column_set.update(row.keys())
+                    row_list.append(row)
+                # hles_cancer_condition: read dog_id, copy and write out as pk_name
+                elif (table_name == "hles_cancer_condition"):
+                    entity_name = pk_prefix + table_name + '_id'
+                    # copy the dog_id
+                    row[entity_name] = row.get('dog_id')
+                    # store data
+                    column_set.update(row.keys())
+                    row_list.append(row)
+                # hles_health_condition: read + copy dog_id and hs_condition
+                # concatenate and write out as pk_name
+                elif (table_name == "hles_health_condition"):
+                    entity_name = pk_prefix + table_name + '_id'
+                    row[entity_name] = ('%s-%s' % (row.get('dog_id'), row.get('hs_condition')))
+                    # store data
+                    column_set.update(row.keys())
+                    row_list.append(row)
+                else:
+                    print("Unrecognized table: %s" % table_name)
+
+    # make sure pk is the first column
+    # pop out the PK, will be splitting this set out later
+    column_set.remove(entity_name)
+    sorted_column_set = sorted(list(column_set))    
+    sorted_column_set.insert(0, entity_name)
+
+    col_count = len(sorted_column_set)
+    print("...%s contains %s rows and %s columns" % (table_name, row_count, col_count))
+
 
     # output to tsv
-    output_location = output_dir + '/' + output_name + '.tsv'
-    with open(output_location, 'w') as output_file:
-        dw = csv.DictWriter(output_file, sorted(list(column_set)), delimiter='\t')
-        dw.writeheader()
-        dw.writerows(row_list)
+    # 512 column max limit per request (upload to workspace) 
+    if (col_count > 512):
+        # calculate chunks needed - each table requires the PK
+        total_col_count = ceil(col_count/512)+col_count-1
+        chunks = ceil(total_col_count/512)
+        print("...Splitting %s into %s files" % (table_name, chunks))
+        print("...{0} cols in init list".format(len(column_set)))
+        # FOR EACH SPLIT
+        for chunk in range(1, chunks+1):
+            # Incremented outfile name
+            output_location = output_dir + '/' + table_name+'_%s' % chunk + '.tsv'
+            print("...Processing Split #{0} to {1}".format(chunk, output_location))
+            with open(output_location, 'w') as output_file:
+                split_column_set = set()
+                # add 511 columns
+                col_counter = 0
+                for col in column_set:
+                    if (col_counter < 511 and len(column_set) > 0):
+                        # add column to split
+                        split_column_set.add(col)
+                        col_counter = len(split_column_set)
+                        printd("......adding {0} to split_column_set ({1}) ...{2} columns left".format(col, col_counter, len(column_set)))
+                # remove the split_column_set from column_set
+                column_set = [x for x in column_set if x not in split_column_set]
+                split_column_list = sorted(list(split_column_set))
+                # add PK to each split as first column                
+                split_column_list.insert(0, entity_name)
+                print("......Split #{0} now contains {1} columns".format(chunk, len(split_column_list)))
+                printd("cols in split: {0}".format(len(split_column_list)))
+                printd("cols left to split: {0}".format(len(column_set)))
+                
+                # split rows
+                split_row_dict_list = list()
+                # iterate through every row looking for every column for this split
+                for row in row_list:
+                    split_row_dict = dict()
+                    for col in split_column_list:
+                        # if a whitelisted col exists in this row
+                        if (col in dict(row).keys()):
+                            # add the col to the split list
+                            split_row_dict[col] = (dict(row).get(col))
+                        else:
+                            pass
+                    split_row_dict_list.append(split_row_dict)
+                # output to tsv
+                dw = csv.DictWriter(output_file, split_column_list, delimiter='\t')
+                dw.writeheader()
+                dw.writerows(split_row_dict_list)
+            print("......{0} Split #{1} was successfully written to {2}".format(table_name, chunk, output_location))
+    else:
+        print("...No need to split files for {0}".format(table_name))
+        output_location = output_dir + '/' + table_name + '.tsv'
+        print("...Writing {0} to {1}".format(table_name, output_location))
+        with open(output_location, 'w') as output_file:
+            dw = csv.DictWriter(output_file, sorted_column_set, delimiter='\t')
+            dw.writeheader()
+            dw.writerows(row_list)
+        print("...{0} was successfully written to {1}".format(table_name, output_location))

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -31,7 +31,7 @@ trait RedCapClient extends Serializable {
 
 object RedCapClient {
   /** URL for the production RedCap API. */
-  private val apiRoute = "http://redcap.fredhutch.org/api/"
+  private val apiRoute = "https://redcap.dogagingproject.org/api/"
 
   /** Formatter matching the production RedCap's interface. */
   private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")


### PR DESCRIPTION
Extended the existing python script to break extra wide tables (> 512 cols) into multiple splits. Only applies to hles_dog at the moment but this is a holdover script until we have the ability to automate updating the DAP Terra workspace and won't need the tsv outputs anymore. Left lots of comments, it's pretty messy and probably could be refactored a little but since this is a temporary solution anyways, not sure if it's worth the time. I thought about rewriting the args collection with argparse and going through and making the loops a little easier to read but again, this is just a hacky script anyways. Let me know your thoughts!

Arguments:
-input directory of transform outputs
-output directory for tsvs
-optional string to provide more verbose printing

Sample Calls:
`python convert-output-to-tsv.py /Users/qhoque/DATA/DAP/transform /Users/qhoque/DATA/DAP/tsv`
`python convert-output-to-tsv.py /Users/qhoque/DATA/DAP/transform /Users/qhoque/DATA/DAP/tsv -d`

Other notes:
This PR includes the switch to the new API url. Should I pull that out and put that into it's own PR under a second ticket because that is a completely unrelated task?

Part of this ticket was also to create an ID for the health condition table using existing values in the data. Dan had me use dog_id + health condition but I hit an issue when I tried to upload these to the Terra workspace because there were duplicate values for some dogs (some dogs had two health conditions with the same health condition ID with the difference being whether it was congenital or not. I updated the code to check this flag and include it as an additional int in the derived ID.