### PR TITLE
Added a new table under jade-tables to store HLES label mappings

### DIFF
--- a/schema/src/main/jade-tables/hles_label_mapping.json
+++ b/schema/src/main/jade-tables/hles_label_mapping.json
@@ -1,0 +1,18 @@
+{
+  "name": "hles_label_mapping",
+  "columns": [
+    {
+      "name": "column_name",
+      "datatype": "string"
+    },
+    {
+      "name": "raw_value",
+      "datatype": "integer",
+      "type": "primary_key"
+    },
+    {
+      "name": "label",
+      "datatype": "string"
+    }
+  ]
+}


### PR DESCRIPTION
Added 3 columns:

column_name (stringified name of the column in the hles_* table)
raw_value (raw number value)
label (string label)

I wasn't sure if the raw_value should be the primary key here or if it should just be the column name.