### PR TITLE
Removed other education from hles_owner

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -22,8 +22,6 @@ object OwnerTransformations {
 
   /** Parse all owner-related fields out of a raw RedCap record. */
   def mapOwner(rawRecord: RawRecord): HlesOwner = {
-    val education = rawRecord.getOptionalNumber("od_education")
-
     val raceValues = rawRecord.fields.get("od_race")
     val otherRace = raceValues.map(_.contains("98"))
 
@@ -36,12 +34,7 @@ object OwnerTransformations {
     HlesOwner(
       ownerId = rawRecord.getRequired("st_owner_id").toLong,
       odAgeRangeYears = rawRecord.getOptionalNumber("od_age"),
-      odMaxEducation = education,
-      odMaxEducationOtherDescription = if (education.contains(98)) {
-        rawRecord.getOptional("od_education_other")
-      } else {
-        None
-      },
+      odMaxEducation = rawRecord.getOptionalNumber("od_education"),
       odRaceWhite = raceValues.map(_.contains("1")),
       odRaceBlackOrAfricanAmerican = raceValues.map(_.contains("2")),
       odRaceAsian = raceValues.map(_.contains("3")),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -10,8 +10,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
   private val exampleOwnerFields = Map[String, Array[String]](
     "st_owner_id" -> Array("10"),
     "od_age" -> Array("5"),
-    "od_education" -> Array("98"),
-    "od_education_other" -> Array("other education"),
+    "od_education" -> Array("2"),
     "od_race" -> Array("1", "4", "98"),
     "od_race_other" -> Array("some description"),
     "od_hispanic_yn" -> Array("1"),
@@ -39,8 +38,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     output.ownerId shouldBe 10
     // owner demographic info
     output.odAgeRangeYears shouldBe Some(5)
-    output.odMaxEducation shouldBe Some(98)
-    output.odMaxEducationOtherDescription shouldBe Some("other education")
+    output.odMaxEducation shouldBe Some(2)
     output.odRaceWhite shouldBe Some(true)
     output.odRaceBlackOrAfricanAmerican shouldBe Some(false)
     output.odRaceAsian shouldBe Some(false)

--- a/schema/src/main/jade-tables/hles_owner.table.json
+++ b/schema/src/main/jade-tables/hles_owner.table.json
@@ -15,10 +15,6 @@
       "datatype": "integer"
     },
     {
-      "name": "od_max_education_other_description",
-      "datatype": "string"
-    },
-    {
       "name": "od_race_white",
       "datatype": "boolean"
     },


### PR DESCRIPTION
Removed `od_max_education_other_description` from hles_owner.table.json
Removed the `odMaxEducationOtherDescription` mapping within the mapOwner function in OwnerTransformations.scala
Removed the education staging variable within the function since it was no longer necessary.
Removed `od_education_other` from the input data within the OwnerTransformationsSpec unit tests.