### PR TITLE
Adding error handling capability (implemented specifically for missing owner_id)

### DIFF
--- a/hles/transformation/src/main/resources/logback.xml
+++ b/hles/transformation/src/main/resources/logback.xml
@@ -10,6 +10,10 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
+    <logger name="org.broadinstitute" level="ERROR" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -11,7 +11,7 @@ object DogTransformations {
 
     rawRecord.getOptional("st_owner_id") match {
       case None =>
-        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
+        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id").log()
         None
       case Some(ownerId) =>
         Some(

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -11,13 +11,13 @@ object DogTransformations {
 
     rawRecord.getOptional("st_owner_id") match {
       case None =>
-        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id").log()
+        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
         None
-      case Some(ownerId) =>
+      case Some(owner_id) =>
         Some(
           HlesDog(
             dogId = dog_id,
-            ownerId = ownerId.toLong,
+            ownerId = owner_id.toLong,
             hlesDogStudyStatus = Some(StudyStatusTransformations.mapStudyStatus(rawRecord)),
             hlesDogDemographics = Some(DemographicsTransformations.mapDemographics(rawRecord)),
             hlesDogResidences = Some(DogResidenceTransformations.mapDogResidences(rawRecord)),

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -6,24 +6,35 @@ import org.broadinstitute.monster.dogaging.jadeschema.table.HlesDog
 object DogTransformations {
 
   /** Parse all dog-related fields out of a raw RedCap record. */
-  def mapDog(rawRecord: RawRecord): HlesDog =
-    HlesDog(
-      dogId = rawRecord.id,
-      ownerId = rawRecord.getRequired("st_owner_id").toLong,
-      hlesDogStudyStatus = Some(StudyStatusTransformations.mapStudyStatus(rawRecord)),
-      hlesDogDemographics = Some(DemographicsTransformations.mapDemographics(rawRecord)),
-      hlesDogResidences = Some(DogResidenceTransformations.mapDogResidences(rawRecord)),
-      hlesDogPhysicalActivity =
-        Some(PhysicalActivityTransformations.mapPhysicalActivity(rawRecord)),
-      hlesDogResidentialEnvironment =
-        Some(ResidentialEnvironmentTransformations.mapResidentialEnvironment(rawRecord)),
-      hlesDogRoutineEnvironment =
-        Some(RoutineEnvironmentTransformations.mapRoutineEnvironment(rawRecord)),
-      hlesDogBehavior = Some(BehaviorTransformations.mapBehavior(rawRecord)),
-      hlesDogDiet = Some(DietTransformations.mapDiet(rawRecord)),
-      hlesDogMedsPreventatives =
-        Some(MedsAndPreventativesTransformations.mapMedsPreventatives(rawRecord)),
-      hlesDogHealthSummary = Some(HealthStatusTransformations.mapHealthSummary(rawRecord)),
-      hlesDogFutureStudies = Some(AdditionalStudiesTransformations.mapFutureStudies(rawRecord))
-    )
+  def mapDog(rawRecord: RawRecord): Option[HlesDog] = {
+    val dog_id = rawRecord.id
+
+    rawRecord.getOptional("st_owner_id") match {
+      case None =>
+        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
+        None
+      case Some(ownerId) =>
+        Some(
+          HlesDog(
+            dogId = dog_id,
+            ownerId = ownerId.toLong,
+            hlesDogStudyStatus = Some(StudyStatusTransformations.mapStudyStatus(rawRecord)),
+            hlesDogDemographics = Some(DemographicsTransformations.mapDemographics(rawRecord)),
+            hlesDogResidences = Some(DogResidenceTransformations.mapDogResidences(rawRecord)),
+            hlesDogPhysicalActivity =
+              Some(PhysicalActivityTransformations.mapPhysicalActivity(rawRecord)),
+            hlesDogResidentialEnvironment =
+              Some(ResidentialEnvironmentTransformations.mapResidentialEnvironment(rawRecord)),
+            hlesDogRoutineEnvironment =
+              Some(RoutineEnvironmentTransformations.mapRoutineEnvironment(rawRecord)),
+            hlesDogBehavior = Some(BehaviorTransformations.mapBehavior(rawRecord)),
+            hlesDogDiet = Some(DietTransformations.mapDiet(rawRecord)),
+            hlesDogMedsPreventatives =
+              Some(MedsAndPreventativesTransformations.mapMedsPreventatives(rawRecord)),
+            hlesDogHealthSummary = Some(HealthStatusTransformations.mapHealthSummary(rawRecord)),
+            hlesDogFutureStudies = Some(AdditionalStudiesTransformations.mapFutureStudies(rawRecord))
+          )
+        )
+    }
+  }
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/DogTransformations.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.dap.dog._
 import org.broadinstitute.monster.dogaging.jadeschema.table.HlesDog
+import org.broadinstitute.monster.dap.HLESurveyTransformationPipelineBuilder.logger
 
 object DogTransformations {
 
@@ -11,7 +12,7 @@ object DogTransformations {
 
     rawRecord.getOptional("st_owner_id") match {
       case None =>
-        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
+        MissingOwnerIdError(s"Record $dog_id has more/less than 1 value for field st_owner_id").log
         None
       case Some(owner_id) =>
         Some(

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.monster.dap
+
+import com.spotify.scio.ScioMetrics.counter
+import org.broadinstitute.monster.dap.PostProcess.errCount
+import org.slf4j.Logger
+import ujson.Obj
+
+// a trait to capture the generic logging mechanism we'll want with case classes for the different logging levels
+abstract class HLESurveyTransformationLog {
+  val jsonMsg: Obj
+
+  def log(implicit logger: Logger): Unit
+}
+
+class HLESurveyTransformationError(msg: String) extends HLESurveyTransformationLog {
+
+  def log(implicit logger: Logger): Unit = {
+    logger.error(jsonMsg.toString())
+    counter("main", errCount).inc()
+  }
+
+  val jsonMsg: Obj = ujson
+    .Obj(
+      "errorType" -> ujson.Str(this.getClass.getSimpleName),
+      "message" -> ujson.Str(msg)
+    )
+}
+
+// case classes for all the different actual warnings and errors we want to raise during the workflow
+case class MissingOwnerId(msg: String) extends HLESurveyTransformationError(msg)

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
@@ -27,4 +27,4 @@ class HLESurveyTransformationError(msg: String) extends HLESurveyTransformationL
 }
 
 // case classes for all the different actual warnings and errors we want to raise during the workflow
-case class MissingOwnerId(msg: String) extends HLESurveyTransformationError(msg)
+case class MissingOwnerIdError(msg: String) extends HLESurveyTransformationError(msg)

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationPipeline.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationPipeline.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.monster.dap
 
+import com.spotify.scio.ScioResult
 import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
 
 /** Entry-point for the HLE transformation pipeline. */
 object HLESurveyTransformationPipeline extends ScioApp[Args] {
 
-  override def pipelineBuilder: PipelineBuilder[Args] =
-    HLESurveyTransformationPipelineBuilder
+  override def pipelineBuilder: PipelineBuilder[Args] = HLESurveyTransformationPipelineBuilder
+  override def postProcess: ScioResult => Unit = PostProcess.postProcess
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationPipelineBuilder.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationPipelineBuilder.scala
@@ -4,16 +4,21 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.values.SCollection
 import org.broadinstitute.monster.common.{PipelineBuilder, StorageIO}
 import org.broadinstitute.monster.common.msg._
+import org.slf4j.{Logger, LoggerFactory}
 
 object HLESurveyTransformationPipelineBuilder extends PipelineBuilder[Args] {
-
   /**
     * Schedule all the steps for the Dog Aging transformation in the given pipeline context.
     *
     * Scheduled steps are launched against the context's runner when the `run()` method
     * is called on it.
+    *
+    * Adding implicit logger so we can associate it with the PipelineBuilder object
     */
+  implicit val logger: Logger = LoggerFactory.getLogger(getClass)
+
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
+
     val rawRecords = readRecords(ctx, args)
     val dogs = rawRecords.transform("Map Dogs")(_.map(DogTransformations.mapDog))
     val owners = rawRecords.transform("Map Owners")(_.map(OwnerTransformations.mapOwner))

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -21,7 +21,8 @@ object OwnerTransformations {
       .map(_.group(1).toLong)
 
   /** Parse all owner-related fields out of a raw RedCap record. */
-  def mapOwner(rawRecord: RawRecord): HlesOwner = {
+  def mapOwner(rawRecord: RawRecord): Option[HlesOwner] = {
+    val dog_id = rawRecord.id
     val raceValues = rawRecord.fields.get("od_race")
     val otherRace = raceValues.map(_.contains("98"))
 
@@ -31,51 +32,62 @@ object OwnerTransformations {
       if (_) rawRecord.getOptionalNumber("oc_address2_own") else None
     }
 
-    HlesOwner(
-      ownerId = rawRecord.getRequired("st_owner_id").toLong,
-      odAgeRangeYears = rawRecord.getOptionalNumber("od_age"),
-      odMaxEducation = rawRecord.getOptionalNumber("od_education"),
-      odRaceWhite = raceValues.map(_.contains("1")),
-      odRaceBlackOrAfricanAmerican = raceValues.map(_.contains("2")),
-      odRaceAsian = raceValues.map(_.contains("3")),
-      odRaceAmericanIndian = raceValues.map(_.contains("4")),
-      odRaceAlaskaNative = raceValues.map(_.contains("5")),
-      odRaceNativeHawaiian = raceValues.map(_.contains("6")),
-      odRaceOtherPacificIslander = raceValues.map(_.contains("7")),
-      odRaceOther = otherRace,
-      odRaceOtherDescription = otherRace.flatMap {
-        if (_) rawRecord.getOptional("od_race_other") else None
-      },
-      odHispanic = rawRecord.getOptionalBoolean("od_hispanic_yn"),
-      odAnnualIncomeRangeUsd = rawRecord.getOptionalNumber("od_income"),
-      ocHouseholdPersonCount = rawRecord.getOptionalNumber("oc_people_household"),
-      ocHouseholdAdultCount = rawRecord.getOptionalNumber("oc_adults_household"),
-      ocHouseholdChildCount = rawRecord.getOptionalNumber("oc_children_household"),
-      ssHouseholdDogCount = rawRecord.getOptionalNumber("ss_num_dogs_hh"),
-      ocPrimaryResidenceState = rawRecord.getOptional("oc_address1_state"),
-      ocPrimaryResidenceCensusDivision = rawRecord.getOptional("oc_address1_division").flatMap {
-        getCensusDivision(_)
-      },
-      ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
-      ocPrimaryResidenceOwnership = primaryAddressOwnership,
-      ocPrimaryResidenceOwnershipOtherDescription = if (primaryAddressOwnership.contains(98)) {
-        rawRecord.getOptional("oc_address1_own_other")
-      } else {
+    rawRecord.getOptional("st_owner_id") match {
+      case None =>
+        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
         None
-      },
-      ocSecondaryResidence = secondaryAddress,
-      ocSecondaryResidenceState = secondaryAddress.flatMap {
-        if (_) rawRecord.getOptional("oc_address2_state") else None
-      },
-      ocSecondaryResidenceZip = secondaryAddress.flatMap {
-        if (_) rawRecord.getOptional("oc_address2_zip") else None
-      },
-      ocSecondaryResidenceOwnership = secondaryAddressOwnership,
-      ocSecondaryResidenceOwnershipOtherDescription = if (secondaryAddressOwnership.contains(98)) {
-        rawRecord.getOptional("oc_address2_own_other")
-      } else {
-        None
-      }
-    )
+      case Some(owner_id) =>
+        Some(
+          HlesOwner(
+            ownerId = owner_id.toLong,
+            odAgeRangeYears = rawRecord.getOptionalNumber("od_age"),
+            odMaxEducation = rawRecord.getOptionalNumber("od_education"),
+            odRaceWhite = raceValues.map(_.contains("1")),
+            odRaceBlackOrAfricanAmerican = raceValues.map(_.contains("2")),
+            odRaceAsian = raceValues.map(_.contains("3")),
+            odRaceAmericanIndian = raceValues.map(_.contains("4")),
+            odRaceAlaskaNative = raceValues.map(_.contains("5")),
+            odRaceNativeHawaiian = raceValues.map(_.contains("6")),
+            odRaceOtherPacificIslander = raceValues.map(_.contains("7")),
+            odRaceOther = otherRace,
+            odRaceOtherDescription = otherRace.flatMap {
+              if (_) rawRecord.getOptional("od_race_other") else None
+            },
+            odHispanic = rawRecord.getOptionalBoolean("od_hispanic_yn"),
+            odAnnualIncomeRangeUsd = rawRecord.getOptionalNumber("od_income"),
+            ocHouseholdPersonCount = rawRecord.getOptionalNumber("oc_people_household"),
+            ocHouseholdAdultCount = rawRecord.getOptionalNumber("oc_adults_household"),
+            ocHouseholdChildCount = rawRecord.getOptionalNumber("oc_children_household"),
+            ssHouseholdDogCount = rawRecord.getOptionalNumber("ss_num_dogs_hh"),
+            ocPrimaryResidenceState = rawRecord.getOptional("oc_address1_state"),
+            ocPrimaryResidenceCensusDivision =
+              rawRecord.getOptional("oc_address1_division").flatMap {
+                getCensusDivision(_)
+              },
+            ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
+            ocPrimaryResidenceOwnership = primaryAddressOwnership,
+            ocPrimaryResidenceOwnershipOtherDescription =
+              if (primaryAddressOwnership.contains(98)) {
+                rawRecord.getOptional("oc_address1_own_other")
+              } else {
+                None
+              },
+            ocSecondaryResidence = secondaryAddress,
+            ocSecondaryResidenceState = secondaryAddress.flatMap {
+              if (_) rawRecord.getOptional("oc_address2_state") else None
+            },
+            ocSecondaryResidenceZip = secondaryAddress.flatMap {
+              if (_) rawRecord.getOptional("oc_address2_zip") else None
+            },
+            ocSecondaryResidenceOwnership = secondaryAddressOwnership,
+            ocSecondaryResidenceOwnershipOtherDescription =
+              if (secondaryAddressOwnership.contains(98)) {
+                rawRecord.getOptional("oc_address2_own_other")
+              } else {
+                None
+              }
+          )
+        )
+    }
   }
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.dogaging.jadeschema.table.HlesOwner
 import scala.util.matching.Regex
+import org.broadinstitute.monster.dap.HLESurveyTransformationPipelineBuilder.logger
 
 object OwnerTransformations {
 
@@ -34,7 +35,7 @@ object OwnerTransformations {
 
     rawRecord.getOptional("st_owner_id") match {
       case None =>
-        MissingOwnerId(s"Record $dog_id has more/less than 1 value for field st_owner_id")
+        MissingOwnerIdError(s"Record $dog_id has less than 1 value for field st_owner_id").log
         None
       case Some(owner_id) =>
         Some(

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/PostProcess.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/PostProcess.scala
@@ -1,0 +1,20 @@
+package org.broadinstitute.monster.dap
+
+import com.spotify.scio.ScioResult
+
+object PostProcess {
+
+  val errCount = "errorCount"
+
+  def postProcess(result: ScioResult): Unit = {
+    result.allCounters.foreach {
+      case (name, count) =>
+        if (name.getName == errCount)
+          count.committed.fold(())(count =>
+            if (count > 0) throw new HLESurveyTransformationFailException
+          )
+    }
+  }
+}
+
+class HLESurveyTransformationFailException extends Exception

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -11,20 +11,22 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
 
   it should "map required fields" in {
     val mapped = DogTransformations.mapDog(RawRecord(1, Map("st_owner_id" -> Array("2"))))
-    mapped shouldBe HlesDog(
-      dogId = 1L,
-      ownerId = 2L,
-      hlesDogStudyStatus = Some(HlesDogStudyStatus.init()),
-      hlesDogDemographics = Some(HlesDogDemographics.init()),
-      hlesDogResidences = Some(HlesDogResidences.init()),
-      hlesDogBehavior = Some(HlesDogBehavior.init()),
-      hlesDogDiet = Some(HlesDogDiet.init()),
-      hlesDogHealthSummary = Some(HlesDogHealthSummary.init()),
-      hlesDogPhysicalActivity = Some(HlesDogPhysicalActivity.init()),
-      hlesDogResidentialEnvironment = Some(HlesDogResidentialEnvironment.init()),
-      hlesDogRoutineEnvironment = Some(HlesDogRoutineEnvironment.init()),
-      hlesDogMedsPreventatives = Some(HlesDogMedsPreventatives.init()),
-      hlesDogFutureStudies = Some(HlesDogFutureStudies.init())
+    mapped shouldBe Some(
+      HlesDog(
+        dogId = 1L,
+        ownerId = 2L,
+        hlesDogStudyStatus = Some(HlesDogStudyStatus.init()),
+        hlesDogDemographics = Some(HlesDogDemographics.init()),
+        hlesDogResidences = Some(HlesDogResidences.init()),
+        hlesDogBehavior = Some(HlesDogBehavior.init()),
+        hlesDogDiet = Some(HlesDogDiet.init()),
+        hlesDogHealthSummary = Some(HlesDogHealthSummary.init()),
+        hlesDogPhysicalActivity = Some(HlesDogPhysicalActivity.init()),
+        hlesDogResidentialEnvironment = Some(HlesDogResidentialEnvironment.init()),
+        hlesDogRoutineEnvironment = Some(HlesDogRoutineEnvironment.init()),
+        hlesDogMedsPreventatives = Some(HlesDogMedsPreventatives.init()),
+        hlesDogFutureStudies = Some(HlesDogFutureStudies.init())
+      )
     )
   }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -30,7 +30,7 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
     )
   }
 
-  it should "verifies that None is returned when st_owner_id is missing" in {
+  it should "should not map dog when st_owner_id is missing" in {
     val mapped = DogTransformations.mapDog(RawRecord(1, Map()))
     mapped shouldBe None
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -31,7 +31,7 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
   }
 
   it should "verifies that None is returned when st_owner_id is missing" in {
-    val mapped = DogTransformations.mapDog(RawRecord(1))
+    val mapped = DogTransformations.mapDog(RawRecord(1, Map()))
     mapped shouldBe None
   }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -29,4 +29,9 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
       )
     )
   }
+
+  it should "verifies that None is returned when st_owner_id is missing" in {
+    val mapped = DogTransformations.mapDog(RawRecord(1))
+    mapped shouldBe None
+  }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.dogaging.jadeschema.table.HlesOwner
+import org.scalactic.Fail
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -35,38 +36,44 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     val exampleOwnerRecord = RawRecord(id = 1, exampleOwnerFields)
     val output = OwnerTransformations.mapOwner(exampleOwnerRecord)
 
-    output.ownerId shouldBe 10
-    // owner demographic info
-    output.odAgeRangeYears shouldBe Some(5)
-    output.odMaxEducation shouldBe Some(2)
-    output.odRaceWhite shouldBe Some(true)
-    output.odRaceBlackOrAfricanAmerican shouldBe Some(false)
-    output.odRaceAsian shouldBe Some(false)
-    output.odRaceAmericanIndian shouldBe Some(true)
-    output.odRaceAlaskaNative shouldBe Some(false)
-    output.odRaceNativeHawaiian shouldBe Some(false)
-    output.odRaceOtherPacificIslander shouldBe Some(false)
-    output.odRaceOther shouldBe Some(true)
-    output.odRaceOtherDescription shouldBe Some("some description")
-    output.odHispanic shouldBe Some(true)
-    // household info fields
-    output.odAnnualIncomeRangeUsd shouldBe Some(2)
-    output.ocHouseholdPersonCount shouldBe Some(2)
-    output.ocHouseholdAdultCount shouldBe Some(2)
-    output.ocHouseholdChildCount shouldBe Some(2)
-    output.ssHouseholdDogCount shouldBe Some(2)
-    // residence fields
-    output.ocPrimaryResidenceState shouldBe Some("OH")
-    output.ocPrimaryResidenceCensusDivision shouldBe Some(3)
-    output.ocPrimaryResidenceZip shouldBe Some("32837-4949")
-    output.ocPrimaryResidenceOwnership shouldBe Some(98)
-    output.ocPrimaryResidenceOwnershipOtherDescription shouldBe Some("some text")
-    output.ocSecondaryResidence shouldBe Some(true)
-    output.ocSecondaryResidenceState shouldBe Some("MA")
-    output.ocSecondaryResidenceZip shouldBe Some("02222")
-    output.ocSecondaryResidenceOwnership shouldBe Some(98)
-    output.ocSecondaryResidenceOwnershipOtherDescription shouldBe Some("some text")
-
+    val truth = {
+      Some(
+        HlesOwner(
+          ownerId = 10,
+          // owner demographic info
+          odAgeRangeYears = Some(5),
+          odMaxEducation = Some(2),
+          odRaceWhite = Some(true),
+          odRaceBlackOrAfricanAmerican = Some(false),
+          odRaceAsian = Some(false),
+          odRaceAmericanIndian = Some(true),
+          odRaceAlaskaNative = Some(false),
+          odRaceNativeHawaiian = Some(false),
+          odRaceOtherPacificIslander = Some(false),
+          odRaceOther = Some(true),
+          odRaceOtherDescription = Some("some description"),
+          odHispanic = Some(true),
+          // household info fields
+          odAnnualIncomeRangeUsd = Some(2),
+          ocHouseholdPersonCount = Some(2),
+          ocHouseholdAdultCount = Some(2),
+          ocHouseholdChildCount = Some(2),
+          ssHouseholdDogCount = Some(2),
+          // residence fields
+          ocPrimaryResidenceState = Some("OH"),
+          ocPrimaryResidenceCensusDivision = Some(3),
+          ocPrimaryResidenceZip = Some("32837-4949"),
+          ocPrimaryResidenceOwnership = Some(98),
+          ocPrimaryResidenceOwnershipOtherDescription = Some("some text"),
+          ocSecondaryResidence = Some(true),
+          ocSecondaryResidenceState = Some("MA"),
+          ocSecondaryResidenceZip = Some("02222"),
+          ocSecondaryResidenceOwnership = Some(98),
+          ocSecondaryResidenceOwnershipOtherDescription = Some("some text")
+        )
+      )
+    }
+    output shouldBe truth
   }
 
   it should "correctly map residence fields when there is no secondary residence" in {
@@ -74,15 +81,19 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
       RawRecord(id = 1, exampleOwnerFields + ("oc_address2_yn" -> Array("0")))
     val output = OwnerTransformations.mapOwner(exampleOwnerRecord)
 
-    output.ocSecondaryResidenceState shouldBe None
-    output.ocSecondaryResidenceZip shouldBe None
-    output.ocSecondaryResidenceOwnership shouldBe None
-    output.ocSecondaryResidenceOwnershipOtherDescription shouldBe None
+    output match {
+      case None => Fail
+      case Some(owner) =>
+        owner.ocSecondaryResidenceState shouldBe None
+        owner.ocSecondaryResidenceZip shouldBe None
+        owner.ocSecondaryResidenceOwnership shouldBe None
+        owner.ocSecondaryResidenceOwnershipOtherDescription shouldBe None
+    }
   }
 
   it should "correctly map owner data when optional fields are null" in {
     val emptyRecord = RawRecord(id = 1, Map[String, Array[String]]("st_owner_id" -> Array("5")))
 
-    OwnerTransformations.mapOwner(emptyRecord) shouldBe HlesOwner.init(ownerId = 5)
+    OwnerTransformations.mapOwner(emptyRecord) shouldBe Some(HlesOwner.init(ownerId = 5))
   }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.dogaging.jadeschema.table.HlesOwner
-import org.scalactic.Fail
+import org.scalatest.FailedStatus
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -82,7 +82,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     val output = OwnerTransformations.mapOwner(exampleOwnerRecord)
 
     output match {
-      case None => Fail
+      case None => FailedStatus
       case Some(owner) =>
         owner.ocSecondaryResidenceState shouldBe None
         owner.ocSecondaryResidenceZip shouldBe None
@@ -95,5 +95,11 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     val emptyRecord = RawRecord(id = 1, Map[String, Array[String]]("st_owner_id" -> Array("5")))
 
     OwnerTransformations.mapOwner(emptyRecord) shouldBe Some(HlesOwner.init(ownerId = 5))
+  }
+
+  it should "should not map owner when st_owner_id is missing" in {
+    val emptyRecord = RawRecord(id = 2, Map())
+
+    OwnerTransformations.mapOwner(emptyRecord) shouldBe None
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.1")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.3")


### PR DESCRIPTION
Bumping ingest-sbt-plugins to 2.1.3
Added a PostProcess object to the transformation project
Added a new TransformationLog file to catch Transformation Errors
Added a case class for MissingOwnerId, we can add additional validations as needed
Updated DogTransformations to check the st_owner_id field and proceed based on it's presence or absence
Had to update the Pipeline code to add the PostProcess object
Had to add an implicit logger class to the PipelineBuilder for it to be associated and picked up within DogTransformations
**Still need to add a good unit test for the case of missing st_owner_id**