### PR TITLE
Adding DAP Pack Count and Date as required fields in the initial extraction filter

### DIFF
--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipelineBuilder.scala
@@ -30,6 +30,8 @@ object HLESurveyExtractionPipelineBuilder {
   )
 
   val ExtractionFilters: Map[String, String] = ExtractedForms
+    .filter(_ == "st_dap_pack_count") // DAP Pack members should have a count
+    .filter(_ == "st_dap_pack_date") // DAP Pack members sh
     .filterNot(_ == "study_status") // For some reason, study_status is never marked as completed.
     .map(form => s"${form}_complete" -> "2") // Magic marker for "completed".
     .toMap + ("co_consent" -> "1")


### PR DESCRIPTION
Need to add some sort of validation for this - would it make more sense to test for this in the integration test or unit test (or both?) ?