### PR TITLE
Refactor extraction pipeline to parameterize form list and extraction filters

### DIFF
--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
@@ -11,6 +11,7 @@ class ExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args]
   import org.broadinstitute.monster.common.msg.MsgOps
 
   val outputDir = File.newTemporaryDirectory()
+  val hlesOutputDir = File(outputDir, HLESurveyExtractionPipeline.subdir)
   override def afterAll(): Unit = outputDir.delete()
 
   val apiToken = {
@@ -52,11 +53,11 @@ class ExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args]
   behavior of "HLESurveyExtractionPipelineBuilder"
 
   it should "successfully download records from RedCap" in {
-    readMsgs(outputDir, "records/*.json") shouldNot be(empty)
+    readMsgs(hlesOutputDir, "records/*.json") shouldNot be(empty)
   }
 
   it should "only download records that have completed all HLES instruments" in {
-    readMsgs(outputDir, "records/*.json").foreach { record =>
+    readMsgs(hlesOutputDir, "records/*.json").foreach { record =>
       HLESurveyExtractionPipeline.extractionFilters
         .get(record.read[String]("field_name"))
         .foreach(expected => record.read[String]("value") shouldBe expected)
@@ -64,11 +65,11 @@ class ExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args]
   }
 
   it should "successfully download data dictionaries from RedCap" in {
-    readMsgs(outputDir, "data_dictionaries/*.json") shouldNot be(empty)
+    readMsgs(hlesOutputDir, "data_dictionaries/*.json") shouldNot be(empty)
   }
 
   it should "not download data dictionaries multiple times" in {
-    val lines = outputDir
+    val lines = hlesOutputDir
       .glob("data_dictionaries/*.json")
       .flatMap(_.lineIterator)
       .map(JsonParser.parseEncodedJson)

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
@@ -57,7 +57,7 @@ class ExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args]
 
   it should "only download records that have completed all HLES instruments" in {
     readMsgs(outputDir, "records/*.json").foreach { record =>
-      HLESurveyExtractionPipeline.HLESExtractionFilters
+      HLESurveyExtractionPipeline.extractionFilters
         .get(record.read[String]("field_name"))
         .foreach(expected => record.read[String]("value") shouldBe expected)
     }

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderIntegrationSpec.scala
@@ -7,7 +7,7 @@ import com.bettercloud.vault.{SslConfig, Vault, VaultConfig}
 import org.broadinstitute.monster.common.PipelineBuilderSpec
 import org.broadinstitute.monster.common.msg.JsonParser
 
-class HLESurveyExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args] {
+class ExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args] {
   import org.broadinstitute.monster.common.msg.MsgOps
 
   val outputDir = File.newTemporaryDirectory()
@@ -57,7 +57,7 @@ class HLESurveyExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderS
 
   it should "only download records that have completed all HLES instruments" in {
     readMsgs(outputDir, "records/*.json").foreach { record =>
-      HLESurveyExtractionPipelineBuilder.ExtractionFilters
+      HLESurveyExtractionPipeline.HLESExtractionFilters
         .get(record.read[String]("field_name"))
         .foreach(expected => record.read[String]("value") shouldBe expected)
     }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -37,6 +37,7 @@ object ExtractionPipelineBuilder {
 class ExtractionPipelineBuilder(
   formsForExtraction: List[String],
   extractionFilters: Map[String, String],
+  jobTag: String,
   idBatchSize: Int,
   getClient: () => RedCapClient
 ) extends PipelineBuilder[Args]
@@ -56,9 +57,7 @@ class ExtractionPipelineBuilder(
           client.get(args.apiToken, input)
       }
 
-    // Start by pulling the IDs of all records that:
-    //  1. Have consented to participate in HLES
-    //  2. Have completed all the HLES forms we care about
+    // Start by pulling the IDs that match the supplied filtering criteria
     val initRequest = GetRecords(
       fields = List("study_id"),
       start = args.startTime,
@@ -105,12 +104,12 @@ class ExtractionPipelineBuilder(
     StorageIO.writeJsonLists(
       extractedRecords,
       "HLE Records",
-      s"${args.outputPrefix}/records"
+      s"${args.outputPrefix}/${jobTag}/records"
     )
     StorageIO.writeJsonLists(
       extractedDataDictionaries,
       "HLE Data Dictionaries",
-      s"${args.outputPrefix}/data_dictionaries"
+      s"${args.outputPrefix}/${jobTag}/data_dictionaries"
     )
     ()
   }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -29,6 +29,8 @@ object ExtractionPipelineBuilder {
   * @param formsForExtraction List of forms to be pulled from RedCap
   * @param extractionFilters Map of filters to be applied whenn pulling RedCap
   *                          data
+  * @param subDir: Sub directory name where data from this pipeline should be
+  *                written
   * @param idBatchSize max number of IDs to include per batch when
   *                    downloading record data
   * @param getClient function that will produce a client which can
@@ -37,7 +39,7 @@ object ExtractionPipelineBuilder {
 class ExtractionPipelineBuilder(
   formsForExtraction: List[String],
   extractionFilters: Map[String, String],
-  jobTag: String,
+  subDir: String,
   idBatchSize: Int,
   getClient: () => RedCapClient
 ) extends PipelineBuilder[Args]
@@ -104,12 +106,12 @@ class ExtractionPipelineBuilder(
     StorageIO.writeJsonLists(
       extractedRecords,
       "HLE Records",
-      s"${args.outputPrefix}/${jobTag}/records"
+      s"${args.outputPrefix}/${subDir}/records"
     )
     StorageIO.writeJsonLists(
       extractedDataDictionaries,
       "HLE Data Dictionaries",
-      s"${args.outputPrefix}/${jobTag}/data_dictionaries"
+      s"${args.outputPrefix}/${subDir}/data_dictionaries"
     )
     ()
   }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -11,34 +11,13 @@ import upack.Msg
 import scala.concurrent.Future
 import scala.collection.JavaConverters._
 
-object HLESurveyExtractionPipelineBuilder {
-
-  /** Names of all forms we want to extract as part of HLE ingest. */
-  val ExtractedForms = List(
-    "recruitment_fields",
-    "owner_contact",
-    "owner_demographics",
-    "dog_demographics",
-    "environment",
-    "physical_activity",
-    "behavior",
-    "diet",
-    "meds_and_preventives",
-    "health_status",
-    "additional_studies",
-    "study_status"
-  )
-
-  val ExtractionFilters: Map[String, String] = ExtractedForms
-    .filterNot(_ == "study_status") // For some reason, study_status is never marked as completed.
-    .map(form => s"${form}_complete" -> "2") // Magic marker for "completed".
-    .toMap + ("co_consent" -> "1")
+object ExtractionPipelineBuilder {
 
   val MaxConcurrentRequests = 8
 }
 
 /**
-  * Builder for the HLE extraction pipeline.
+  * Builder for an extraction pipeline.
   *
   * Sets up the pipeline to:
   *   1. Query the study IDs of all dogs, possibly within a fixed
@@ -47,12 +26,17 @@ object HLESurveyExtractionPipelineBuilder {
   *   3. Download the values of all HLE forms for each batch of IDs
   *   4. Write the downloaded forms to storage
   *
+  * @param formsForExtraction List of forms to be pulled from RedCap
+  * @param extractionFilters Map of filters to be applied whenn pulling RedCap
+  *                          data
   * @param idBatchSize max number of IDs to include per batch when
   *                    downloading record data
   * @param getClient function that will produce a client which can
   *                  interact with a RedCap API
   */
-class HLESurveyExtractionPipelineBuilder(
+class ExtractionPipelineBuilder(
+  formsForExtraction: List[String],
+  extractionFilters: Map[String, String],
   idBatchSize: Int,
   getClient: () => RedCapClient
 ) extends PipelineBuilder[Args]
@@ -60,7 +44,7 @@ class HLESurveyExtractionPipelineBuilder(
 
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     import org.broadinstitute.monster.common.msg.MsgOps
-    import HLESurveyExtractionPipelineBuilder._
+    import ExtractionPipelineBuilder._
 
     val lookupFn =
       new ScalaAsyncLookupDoFn[RedcapRequest, Msg, RedCapClient](MaxConcurrentRequests) {
@@ -79,7 +63,7 @@ class HLESurveyExtractionPipelineBuilder(
       fields = List("study_id"),
       start = args.startTime,
       end = args.endTime,
-      filters = ExtractionFilters
+      filters = extractionFilters
     )
     val idsToExtract = ctx
       .parallelize(Iterable(initRequest))
@@ -99,7 +83,7 @@ class HLESurveyExtractionPipelineBuilder(
       .map { ids =>
         GetRecords(
           ids = ids.getValue.asScala.toList,
-          forms = ExtractedForms,
+          forms = formsForExtraction,
           // Pull the consent field so we can QC that the filter is working properly.
           fields = List("co_consent")
         )
@@ -112,7 +96,7 @@ class HLESurveyExtractionPipelineBuilder(
 
     // Download the data dictionary for every form.
     val extractedDataDictionaries = ctx
-      .parallelize(ExtractedForms)
+      .parallelize(formsForExtraction)
       .map(instrument => GetDataDictionary(instrument))
       .transform("Get data dictionary") {
         _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -8,8 +8,29 @@ import Args._
 /** Entry-point for the HLE extraction pipeline. */
 object HLESurveyExtractionPipeline extends ScioApp[Args] {
 
+  /** Names of all forms we want to extract as part of HLE ingest. */
+  val HLESForms = List(
+    "recruitment_fields",
+    "owner_contact",
+    "owner_demographics",
+    "dog_demographics",
+    "environment",
+    "physical_activity",
+    "behavior",
+    "diet",
+    "meds_and_preventives",
+    "health_status",
+    "additional_studies",
+    "study_status"
+  )
+
+  val HLESExtractionFilters: Map[String, String] = HLESForms
+    .filterNot(_ == "study_status") // For some reason, study_status is never marked as completed.
+    .map(form => s"${form}_complete" -> "2") // Magic marker for "completed".
+    .toMap + ("co_consent" -> "1")
+
   override def pipelineBuilder: PipelineBuilder[Args] =
     // Use a batch size of 100 because it seems to work well enough.
     // We might need to revisit this as more dogs are consented.
-    new HLESurveyExtractionPipelineBuilder(100, RedCapClient.apply)
+    new ExtractionPipelineBuilder(HLESForms, HLESExtractionFilters, 100, RedCapClient.apply)
 }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -29,10 +29,10 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
     .map(form => s"${form}_complete" -> "2") // Magic marker for "completed".
     .toMap + ("co_consent" -> "1")
 
-  val jobTag = "hles"
+  val subdir = "hles"
 
   override def pipelineBuilder: PipelineBuilder[Args] =
     // Use a batch size of 100 because it seems to work well enough.
     // We might need to revisit this as more dogs are consented.
-    new ExtractionPipelineBuilder(forms, extractionFilters, jobTag, 100, RedCapClient.apply)
+    new ExtractionPipelineBuilder(forms, extractionFilters, subdir, 100, RedCapClient.apply)
 }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -9,7 +9,7 @@ import Args._
 object HLESurveyExtractionPipeline extends ScioApp[Args] {
 
   /** Names of all forms we want to extract as part of HLE ingest. */
-  val HLESForms = List(
+  val forms = List(
     "recruitment_fields",
     "owner_contact",
     "owner_demographics",
@@ -24,13 +24,15 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
     "study_status"
   )
 
-  val HLESExtractionFilters: Map[String, String] = HLESForms
+  val extractionFilters: Map[String, String] = forms
     .filterNot(_ == "study_status") // For some reason, study_status is never marked as completed.
     .map(form => s"${form}_complete" -> "2") // Magic marker for "completed".
     .toMap + ("co_consent" -> "1")
 
+  val jobTag = "hles"
+
   override def pipelineBuilder: PipelineBuilder[Args] =
     // Use a batch size of 100 because it seems to work well enough.
     // We might need to revisit this as more dogs are consented.
-    new ExtractionPipelineBuilder(HLESForms, HLESExtractionFilters, 100, RedCapClient.apply)
+    new ExtractionPipelineBuilder(forms, extractionFilters, jobTag, 100, RedCapClient.apply)
 }

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -9,7 +9,6 @@ import upack._
 import scala.collection.mutable
 
 object ExtractionPipelineBuilderSpec {
-
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()
   val end = start.plusDays(3).plusHours(10).minusSeconds(100)
@@ -81,7 +80,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
       getClient = () => mockClient
     )
 
-  behavior of "HLESurveyExtractionPipelineBuilder"
+  behavior of "ExtractionPipelineBuilder"
 
   it should "query RedCap for records correctly" in {
     mockClient.recordedRequests.toSet should contain allElementsOf (Set(initQuery)

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -41,10 +41,10 @@ object ExtractionPipelineBuilderSpec {
   }
 
   val downloadDataDictionary =
-    HLESurveyExtractionPipeline.forms.map(instrument => GetDataDictionary(instrument): RedcapRequest)
+    forms.map(instrument => GetDataDictionary(instrument): RedcapRequest)
 
   val expectedDataDictionary =
-    HLESurveyExtractionPipeline.forms.map(i => Obj(Str("value") -> Str(i)): Msg)
+    forms.map(i => Obj(Str("value") -> Str(i)): Msg)
 
   val mockClient = new MockRedCapClient(
     token,
@@ -62,6 +62,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
   import ExtractionPipelineBuilderSpec._
 
   val outputDir = File.newTemporaryDirectory()
+
   override def afterAll(): Unit = outputDir.delete()
 
   override val testArgs = Args(
@@ -75,7 +76,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
     new ExtractionPipelineBuilder(
       forms,
       filters,
-      "fake_job_tag",
+      "",
       idBatchSize = 1,
       getClient = () => mockClient
     )

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -8,8 +8,8 @@ import upack._
 
 import scala.collection.mutable
 
-object HLESurveyExtractionPipelineBuilderSpec {
-  import HLESurveyExtractionPipelineBuilder._
+object ExtractionPipelineBuilderSpec {
+  import ExtractionPipelineBuilder._
 
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()
@@ -57,8 +57,8 @@ object HLESurveyExtractionPipelineBuilderSpec {
   )
 }
 
-class HLESurveyExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
-  import HLESurveyExtractionPipelineBuilderSpec._
+class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
+  import ExtractionPipelineBuilderSpec._
 
   val outputDir = File.newTemporaryDirectory()
   override def afterAll(): Unit = outputDir.delete()
@@ -71,7 +71,7 @@ class HLESurveyExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
   )
 
   override val builder =
-    new HLESurveyExtractionPipelineBuilder(idBatchSize = 1, getClient = () => mockClient)
+    new ExtractionPipelineBuilder(idBatchSize = 1, getClient = () => mockClient)
 
   behavior of "HLESurveyExtractionPipelineBuilder"
 

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -9,7 +9,6 @@ import upack._
 import scala.collection.mutable
 
 object ExtractionPipelineBuilderSpec {
-  import ExtractionPipelineBuilder._
 
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()


### PR DESCRIPTION
## Why

We will need to vary the extraction filters between CSLB and HLES. 

## This PR
* Renames the `HLESExtractionPipelineBuilder` to `ExtractionPipelineBuilder`
* Parameterizes the form list and extraction filters in the `ExtractionPipelineBuilder` so we can use different values for CSLB
* Adds a `subdir` parameter we'll use to determine the output sub-directory for the data