### PR TITLE
Upgrade other instances of this setup-scala task to fix error on build

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master


### PR DESCRIPTION
## Why
Master can't build due to [errors](https://github.com/DataBiosphere/dog-aging-ingest/runs/1442519507) when setting up scala in the needed GitHub workflows.

## This PR
* Upgrades to a newer version of the `setup-scala` GitHub action, which fixed the issue for the `validate-pull-request` workflow.