### PR TITLE
Shift to new ingest-utils json parsing method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val `dog-aging-hles-extraction` = project
   .enablePlugins(MonsterScioPipelinePlugin)
   .settings(
     libraryDependencies += "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-    libraryDependencies += "com.bettercloud" % "vault-java-driver" % vaultDriverVersion % IntegrationTest
+    libraryDependencies += "com.bettercloud" % "vault-java-driver" % vaultDriverVersion % IntegrationTest,
+    IntegrationTest / parallelExecution := false
   )
 
 lazy val `dog-aging-hles-transformation` = project

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
@@ -5,7 +5,6 @@ import java.time.{LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
 import better.files.File
 import com.bettercloud.vault.{SslConfig, Vault, VaultConfig}
 import org.broadinstitute.monster.common.PipelineBuilderSpec
-import org.broadinstitute.monster.common.msg.JsonParser
 
 class CslbExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args] {
   import org.broadinstitute.monster.common.msg.MsgOps
@@ -47,7 +46,8 @@ class CslbExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   val end =
     OffsetDateTime.of(LocalDate.of(2020, 11, 16), LocalTime.MIDNIGHT, ZoneOffset.UTC)
 
-  override val testArgs = Args(apiToken, Some(start), Some(end), outputDir.pathAsString)
+  override val testArgs =
+    Args(apiToken, Some(start), Some(end), outputDir.pathAsString, pullDataDictionaries = false)
   override val builder = CslbExtractionPipeline.pipelineBuilder
 
   behavior of "CslbSurveyExtractionPipelineBuilder"
@@ -62,19 +62,5 @@ class CslbExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
         .get(record.read[String]("field_name"))
         .foreach(expected => record.read[String]("value") shouldBe expected)
     }
-  }
-
-  it should "successfully download data dictionaries from RedCap" in {
-    readMsgs(cslbOutputDir, "data_dictionaries/*.json") shouldNot be(empty)
-  }
-
-  it should "not download data dictionaries multiple times" in {
-    val lines = cslbOutputDir
-      .glob("data_dictionaries/*.json")
-      .flatMap(_.lineIterator)
-      .map(JsonParser.parseEncodedJson)
-      .toList
-
-    lines.length shouldBe lines.toSet.size
   }
 }

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -5,7 +5,6 @@ import java.time.{LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
 import better.files.File
 import com.bettercloud.vault.{SslConfig, Vault, VaultConfig}
 import org.broadinstitute.monster.common.PipelineBuilderSpec
-import org.broadinstitute.monster.common.msg.JsonParser
 
 class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args] {
   import org.broadinstitute.monster.common.msg.MsgOps
@@ -47,7 +46,8 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   val end =
     OffsetDateTime.of(LocalDate.of(2020, 2, 2), LocalTime.MIDNIGHT, ZoneOffset.UTC)
 
-  override val testArgs = Args(apiToken, Some(start), Some(end), outputDir.pathAsString)
+  override val testArgs =
+    Args(apiToken, Some(start), Some(end), outputDir.pathAsString, pullDataDictionaries = false)
   override val builder = HLESurveyExtractionPipeline.pipelineBuilder
 
   behavior of "HLESurveyExtractionPipelineBuilder"
@@ -62,19 +62,5 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
         .get(record.read[String]("field_name"))
         .foreach(expected => record.read[String]("value") shouldBe expected)
     }
-  }
-
-  it should "successfully download data dictionaries from RedCap" in {
-    readMsgs(hlesOutputDir, "data_dictionaries/*.json") shouldNot be(empty)
-  }
-
-  it should "not download data dictionaries multiple times" in {
-    val lines = hlesOutputDir
-      .glob("data_dictionaries/*.json")
-      .flatMap(_.lineIterator)
-      .map(JsonParser.parseEncodedJson)
-      .toList
-
-    lines.length shouldBe lines.toSet.size
   }
 }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/Args.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/Args.scala
@@ -19,7 +19,12 @@ case class Args(
   @HelpMessage("Only extract records created/updated before or at this time")
   endTime: Option[OffsetDateTime],
   @HelpMessage("Path where extracted JSON should be written")
-  outputPrefix: String
+  outputPrefix: String,
+  /** data dictionary pulls are optional;
+    * the REDCap API is extremely flaky when pulling this data down
+    */
+  @HelpMessage("Extract data dictionaries")
+  pullDataDictionaries: Boolean
 )
 
 object Args {

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -104,12 +104,12 @@ class ExtractionPipelineBuilder(
         _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
       }
 
-    StorageIO.writeJsonLists(
+    StorageIO.writeJsonListsGeneric(
       extractedRecords,
       "Write records",
       s"${args.outputPrefix}/${subDir}/records"
     )
-    StorageIO.writeJsonLists(
+    StorageIO.writeJsonListsGeneric(
       extractedDataDictionaries,
       "Write data dictionaries",
       s"${args.outputPrefix}/${subDir}/data_dictionaries"

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -96,24 +96,27 @@ class ExtractionPipelineBuilder(
       _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
     }
 
-    // Download the data dictionary for every form.
-    val extractedDataDictionaries = ctx
-      .parallelize(formsForExtraction)
-      .map(instrument => GetDataDictionary(instrument))
-      .transform("Get data dictionary") {
-        _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
-      }
+    if (args.pullDataDictionaries) {
+      // Download the data dictionary for every form.
+      val extractedDataDictionaries = ctx
+        .parallelize(formsForExtraction)
+        .map(instrument => GetDataDictionary(instrument))
+        .transform("Get data dictionary") {
+          _.applyKvTransform(ParDo.of(lookupFn)).flatMap(kv => kv.getValue.fold(throw _, _.arr))
+        }
+      StorageIO.writeJsonListsGeneric(
+        extractedDataDictionaries,
+        "Write data dictionaries",
+        s"${args.outputPrefix}/${subDir}/data_dictionaries"
+      )
+    }
 
     StorageIO.writeJsonListsGeneric(
       extractedRecords,
       "Write records",
       s"${args.outputPrefix}/${subDir}/records"
     )
-    StorageIO.writeJsonListsGeneric(
-      extractedDataDictionaries,
-      "Write data dictionaries",
-      s"${args.outputPrefix}/${subDir}/data_dictionaries"
-    )
+
     ()
   }
 }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -124,8 +124,14 @@ object RedCapClient {
         .enqueue(new Callback {
           override def onFailure(call: Call, e: IOException): Unit =
             p.failure(e)
-          override def onResponse(call: Call, response: Response): Unit =
-            p.success(JsonParser.parseEncodedJson(response.body().string()))
+          override def onResponse(call: Call, response: Response): Unit = {
+            val maybeResult = JsonParser.parseWithTry(response.body().string())
+            maybeResult match {
+              case Right(result) => p.success(result)
+              case Left(err)     => p.failure(err)
+            }
+
+          }
         })
       p.future
     }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.time.Duration
 import java.time.format.DateTimeFormatter
 
-import okhttp3.{Call, Callback, FormBody, OkHttpClient, Request, Response}
+import okhttp3._
 import org.broadinstitute.monster.common.msg.JsonParser
 import org.slf4j.LoggerFactory
 import upack.Msg
@@ -125,12 +125,12 @@ object RedCapClient {
           override def onFailure(call: Call, e: IOException): Unit =
             p.failure(e)
           override def onResponse(call: Call, response: Response): Unit = {
-            val maybeResult = JsonParser.parseWithTry(response.body().string())
+            val maybeResult =
+              JsonParser.parseEncodedJsonReturningFailure(response.body().string())
             maybeResult match {
               case Right(result) => p.success(result)
               case Left(err)     => p.failure(err)
             }
-
           }
         })
       p.future

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -71,7 +71,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
     startTime = Some(start),
     endTime = Some(end),
     outputPrefix = outputDir.pathAsString,
-    pullDataDictionaries = false
+    pullDataDictionaries = true
   )
 
   override val builder =

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -70,7 +70,8 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
     apiToken = token,
     startTime = Some(start),
     endTime = Some(end),
-    outputPrefix = outputDir.pathAsString
+    outputPrefix = outputDir.pathAsString,
+    pullDataDictionaries = false
   )
 
   override val builder =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.3")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.4")


### PR DESCRIPTION
## Why

The DAP pipeline does not terminate cleanly if an exception is thrown from the Redcap client (usually if non-JSON garbage is returned). We should handle that situation and terminate.

## This PR
* Shifts to a new json parsing method introduced in ingest-utils 2.1.4 that returns an `Either[ParsingFailure, Msg]` that we will match against. 

