### PR TITLE
[DSPDC-1331] Implement DAP pack filtering

### DIFF
--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
@@ -59,8 +59,8 @@ class CslbExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   it should "only download records that have completed all CSLB instruments" in {
     readMsgs(cslbOutputDir, "records/*.json").foreach { record =>
       CslbExtractionPipeline.extractionFilters
-        .get(record.read[String]("field_name"))
-        .foreach(expected => record.read[String]("value") shouldBe expected)
+        .find(directive => directive.field == record.read[String]("field_name"))
+        .foreach(expected => record.read[String]("value") shouldBe expected.field)
     }
   }
 

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -59,8 +59,8 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   it should "only download records that have completed all HLES instruments" in {
     readMsgs(hlesOutputDir, "records/*.json").foreach { record =>
       HLESurveyExtractionPipeline.extractionFilters
-        .get(record.read[String]("field_name"))
-        .foreach(expected => record.read[String]("value") shouldBe expected)
+        .find(directive => directive.field == record.read[String]("field_name"))
+        .foreach(expected => record.read[String]("value") shouldBe expected.field)
     }
   }
 

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
@@ -13,8 +13,8 @@ object CslbExtractionPipeline extends ScioApp[Args] {
   // Magic marker for "completed".
   // NB: We are purposefully excluding the recruitment_fields_complete -> 2
   // mapping, as that conflicts with the CSLB data
-  val extractionFilters: Map[String, String] = Map(
-    s"canine_social_and_learned_behavior_complete" -> "2"
+  val extractionFilters: List[FilterDirective] = List(
+    FilterDirective("canine_social_and_learned_behavior_complete", FilterOps.==, "2")
   )
 
   val subdir = "cslb"

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -38,7 +38,7 @@ object ExtractionPipelineBuilder {
   */
 class ExtractionPipelineBuilder(
   formsForExtraction: List[String],
-  extractionFilters: Map[String, String],
+  extractionFilters: List[FilterDirective],
   arm: String,
   subDir: String,
   idBatchSize: Int,

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.monster.dap
+
+sealed trait FilterOp {
+  def op: String
+}
+
+object FilterOps {
+  case object == extends FilterOp {
+    def op: String = "="
+  }
+
+  case object > extends FilterOp {
+    def op: String = ">"
+  }
+}
+
+/**
+  * Represents a typesafe REDCap filterLogic directive.
+  * Their API expects directives to be of the form [field][op][value]
+  */
+case class FilterDirective(field: String, operation: FilterOp, comparand: String)

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
@@ -5,6 +5,7 @@ sealed trait FilterOp {
 }
 
 object FilterOps {
+
   case object == extends FilterOp {
     def op: String = "="
   }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -58,7 +58,7 @@ object RedCapClient {
             s"forms: [${forms.mkString(",")}]",
             s"start: [$start]",
             s"end: [$end]",
-            s"filters: [${filters.map { case (k, v) => s"$k=$v" }.mkString(",")}]"
+            s"filters: [${filters.map(directive => s"${directive.field}${directive.operation.op}${directive.comparand}").mkString(",")}]"
           )
           logger.debug(s"Querying RedCap for records: ${logPieces.mkString(",")}")
 
@@ -94,7 +94,9 @@ object RedCapClient {
           if (filters.nonEmpty) {
             formBuilder.add(
               "filterLogic",
-              filters.map { case (k, v) => s"[$k]=$v" }.mkString(" and ")
+              filters.map { directive =>
+                s"[${directive.field}]${directive.operation.op}${directive.comparand}"
+              }.mkString(" and ")
             )
           }
           formBuilder

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedcapRequest.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedcapRequest.scala
@@ -28,7 +28,7 @@ case class GetRecords(
   forms: List[String] = Nil,
   start: Option[OffsetDateTime] = None,
   end: Option[OffsetDateTime] = None,
-  filters: Map[String, String] = Map.empty
+  filters: List[FilterDirective] = List.empty
 ) extends RedcapRequest
 
 /**

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -16,7 +16,7 @@ object ExtractionPipelineBuilderSpec {
 
   val fakeIds = 1 to 50
   val forms = List("fake_form_1", "fake_form_2")
-  val filters = Map("foo" -> "Bar")
+  val filters = List(FilterDirective("foo", FilterOps.==, "Bar"))
 
   val initQuery = GetRecords(
     start = Some(start),


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1331)

We want to filter for 
* the presence of `st_dap_pack_count`
* the presence of `st_dap_pack_date`

In my testing, the REDCap API does not support "not null" conditions, so I've implemented something more hacky where we check for `st_dap_pack_count` > 0 and `st_dap_pack_date` > some magic date in the past.

## This PR
* We had hardcoded our filtering logic in the redcap client to only support `=`. I've extracted the filtering directives to their own typesafe class so we can now support other operands (">" for now).
* Updates the CSLB + HLES pipelines with the new filtering approach, and adds the DAP pack filters to the HLES pipeline.
