### PR TITLE
Adding schema files for environment data

### DIFF
--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
+
+// Ignore IntelliJ, this is used to make the implicit parser compile.
 import Args._
 
 object CslbExtractionPipeline extends ScioApp[Args] {
@@ -18,13 +20,15 @@ object CslbExtractionPipeline extends ScioApp[Args] {
   )
 
   val subdir = "cslb"
-  val arm = "annual_2020_arm_1"
+  val arm = List("annual_2020_arm_1")
+  val fieldList = List("co_consent")
 
   override def pipelineBuilder: PipelineBuilder[Args] =
     new ExtractionPipelineBuilder(
       forms,
       extractionFilters,
       arm,
+      fieldList,
       subdir,
       100,
       RedCapClient.apply

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.monster.dap
+
+import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
+
+// Ignore IntelliJ, this is used to make the implicit parser compile.
+import Args._
+
+object EnvironmentExtractionPipeline extends ScioApp[Args] {
+
+  val forms = List(
+    "geocoding_metadata",
+    "census_variables",
+    "pollutant_variables",
+    "temperature_and_precipitation_variables",
+    "walkability_variables"
+  )
+
+  // Magic marker for "completed".
+  // NB: We are looking for baseline_complete -> 2
+  val extractionFilters: List[FilterDirective] = List(
+    FilterDirective("baseline_complete", FilterOps.==, "2")
+  )
+
+  val subdir = "environment"
+  //todo: need to query for all arms and work through arms serially
+  val arm =
+    List("baseline_arm_1", "dec2019_arm_1", "jan2020_arm_1")
+  val fieldList = List("baseline_complete")
+
+  override def pipelineBuilder: PipelineBuilder[Args] =
+    new ExtractionPipelineBuilder(
+      forms,
+      extractionFilters,
+      arm,
+      fieldList,
+      subdir,
+      100,
+      RedCapClient.apply
+    )
+}

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -39,10 +39,11 @@ object ExtractionPipelineBuilder {
 class ExtractionPipelineBuilder(
   formsForExtraction: List[String],
   extractionFilters: List[FilterDirective],
-  arm: String,
+  arm: List[String],
+  fieldList: List[String],
   subDir: String,
   idBatchSize: Int,
-  getClient: String => RedCapClient
+  getClient: List[String] => RedCapClient
 ) extends PipelineBuilder[Args]
     with Serializable {
 
@@ -87,7 +88,7 @@ class ExtractionPipelineBuilder(
           ids = ids.getValue.asScala.toList,
           forms = formsForExtraction,
           // Pull the consent field so we can QC that the filter is working properly.
-          fields = List("co_consent")
+          fields = fieldList
         )
       }
 

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -35,7 +35,9 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
   ) // Magic marker for "completed".
 
   val subdir = "hles"
-  val arm = "baseline_arm_1"
+  // Limit to the initial HLE event.
+  val arm = List("baseline_arm_1")
+  val fieldList = List("co_consent")
 
   override def pipelineBuilder: PipelineBuilder[Args] =
     // Use a batch size of 100 because it seems to work well enough.
@@ -44,6 +46,7 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
       forms,
       extractionFilters,
       arm,
+      fieldList,
       subdir,
       100,
       RedCapClient.apply

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -40,7 +40,7 @@ object RedCapClient {
   private val timeout = Duration.ofSeconds(60)
 
   /** Construct a client instance backed by the production RedCap instance. */
-  def apply(arm: String): RedCapClient = {
+  def apply(arm: List[String]): RedCapClient = {
     val logger = LoggerFactory.getLogger(getClass)
 
     val client = new OkHttpClient.Builder()
@@ -64,8 +64,6 @@ object RedCapClient {
 
           val formBuilder = new FormBody.Builder()
             .add("token", apiToken)
-            // Limit to the initial HLE event.
-            .add("events[0]", arm)
             // Export individual survey records as JSON.
             .add("content", "record")
             .add("format", "json")
@@ -79,6 +77,10 @@ object RedCapClient {
             // Honestly not sure what these do, haven't seen the need to make them 'true'.
             .add("exportSurveyFields", "false")
             .add("exportDataAccessGroups", "false")
+          // Parameterized arm
+          if (arm.nonEmpty) {
+            formBuilder.add("events", arm.mkString(","))
+          }
 
           ids.zipWithIndex.foreach {
             case (id, i) => formBuilder.add(s"records[$i]", id)

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -12,11 +12,12 @@ object ExtractionPipelineBuilderSpec {
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()
   val end = start.plusDays(3).plusHours(10).minusSeconds(100)
-  val event = "fake_event_1"
+  val event = List("fake_event_1")
 
   val fakeIds = 1 to 50
   val forms = List("fake_form_1", "fake_form_2")
   val filters = List(FilterDirective("foo", FilterOps.==, "Bar"))
+  val fields = List("co_consent")
 
   val initQuery = GetRecords(
     start = Some(start),
@@ -79,6 +80,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
       forms,
       filters,
       event,
+      fields,
       "",
       idBatchSize = 1,
       getClient = _ => mockClient

--- a/schema/src/main/jade-fragments/environment_census.fragment.json
+++ b/schema/src/main/jade-fragments/environment_census.fragment.json
@@ -1,0 +1,105 @@
+{
+  "name": "environment_census",
+  "columns": [
+    {
+      "name": "cv_population_estimate",
+      "datatype": "integer"
+    },
+    {
+      "name": "cv_area_sqmi",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_population_density",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanic_white",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanic_black",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanica_ian",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanic_asian",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanicn_hpi",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanic_other",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_nothispanic_two_or_more",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_hispanic",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_female",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_median_income",
+      "datatype": "integer"
+    },
+    {
+      "name": "cv_gini_index",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_below_125povline",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_jobless16to64mf",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_famsownchild_female_led",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_less_than_ba_degree",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_less_than_100k",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_disadvantage_index",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_same_house_1yrago",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_owner_occupied",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_pct_us_born",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_stability_index",
+      "datatype": "float"
+    },
+    {
+      "name": "cv_data_year",
+      "datatype": "integer"
+    }
+  ]
+}

--- a/schema/src/main/jade-fragments/environment_geocoding.fragment.json
+++ b/schema/src/main/jade-fragments/environment_geocoding.fragment.json
@@ -1,0 +1,29 @@
+{
+  "name": "environment_geocoding",
+  "columns": [
+    {
+      "name": "gm_address_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "gm_match_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "gm_state_fips",
+      "datatype": "string"
+    },
+    {
+      "name": "gm_geocoder",
+      "datatype": "integer"
+    },
+    {
+      "name": "gm_entry_type",
+      "datatype": "integer"
+    },
+    {
+      "name": "gm_complete",
+      "datatype": "integer"
+    }
+  ]
+}

--- a/schema/src/main/jade-fragments/environment_pollutants.fragment.json
+++ b/schema/src/main/jade-fragments/environment_pollutants.fragment.json
@@ -1,0 +1,37 @@
+{
+  "name": "environment_pollutants",
+  "columns": [
+    {
+      "name": "pv_data_year",
+      "datatype": "integer"
+    },
+    {
+      "name": "pv_co",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_no2",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_o3",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_pm10",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_pm25",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_so2",
+      "datatype": "float"
+    },
+    {
+      "name": "pv_complete",
+      "datatype": "integer"
+    }
+  ]
+}

--- a/schema/src/main/jade-fragments/environment_temperature_precipitation.fragment.json
+++ b/schema/src/main/jade-fragments/environment_temperature_precipitation.fragment.json
@@ -1,0 +1,397 @@
+{
+  "name": "environment_temperature_precipitation",
+  "columns": [
+    {
+      "name": "tp_data_year",
+      "datatype": "integer"
+    },
+    {
+      "name": "tp_pcpn_annual_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_annual_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_annual_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_annual_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_annual_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_norm_data_year",
+      "datatype": "integer"
+    },
+    {
+      "name": "tp_pcpn_norm_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_pcpn_norm_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmpc_norm_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmax_norm_12",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_01",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_02",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_03",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_04",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_05",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_06",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_07",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_08",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_09",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_10",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_11",
+      "datatype": "float"
+    },
+    {
+      "name": "tp_tmin_norm_12",
+      "datatype": "float"
+    }
+  ]
+}

--- a/schema/src/main/jade-fragments/environment_walkability.fragment.json
+++ b/schema/src/main/jade-fragments/environment_walkability.fragment.json
@@ -1,0 +1,29 @@
+{
+  "name": "environment_walkability",
+  "columns": [
+    {
+      "name": "wv_walkscore",
+      "datatype": "float"
+    },
+    {
+      "name": "wv_walkscore_descrip",
+      "datatype": "integer"
+    },
+    {
+      "name": "wv_walkscore_date",
+      "datatype": "string"
+    },
+    {
+      "name": "wv_housing_units",
+      "datatype": "float"
+    },
+    {
+      "name": "wv_res_density",
+      "datatype": "float"
+    },
+    {
+      "name": "wv_density_data_year",
+      "datatype": "integer"
+    }
+  ]
+}

--- a/schema/src/main/jade-tables/environment.table.json
+++ b/schema/src/main/jade-tables/environment.table.json
@@ -1,0 +1,28 @@
+{
+  "name": "environment",
+  "columns": [
+    {
+      "name": "dog_id",
+      "datatype": "integer",
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "hles_dog",
+          "column_name": "dog_id"
+        }
+      ]
+    },
+    {
+      "name": "address_month_year",
+      "datatype": "string",
+      "type": "primary_key"
+    }
+  ],
+  "table_fragments": [
+    "environment_geocoding",
+    "environment_census",
+    "environment_pollutants",
+    "environment_temperature_precipitation",
+    "environment_walkability"
+  ]
+}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1287)
This is the first PR in a series to get the DAP environmental data extracted from RedCap.
We are breaking a larger more convoluted PR into smaller pieces and this is the first of that series.

## This PR

- Added a new json schema file for the environment table including 5 jade fragments 
