### PR TITLE
Add extraction code to pull environment data

### DIFF
--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/CslbExtractionPipeline.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.monster.dap
 
 import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
+
+// Ignore IntelliJ, this is used to make the implicit parser compile.
 import Args._
 
 object CslbExtractionPipeline extends ScioApp[Args] {
@@ -18,13 +20,15 @@ object CslbExtractionPipeline extends ScioApp[Args] {
   )
 
   val subdir = "cslb"
-  val arm = "annual_2020_arm_1"
+  val arm = List("annual_2020_arm_1")
+  val fieldList = List("co_consent")
 
   override def pipelineBuilder: PipelineBuilder[Args] =
     new ExtractionPipelineBuilder(
       forms,
       extractionFilters,
       arm,
+      fieldList,
       subdir,
       100,
       RedCapClient.apply

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.monster.dap
+
+import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
+
+// Ignore IntelliJ, this is used to make the implicit parser compile.
+import Args._
+
+object EnvironmentExtractionPipeline extends ScioApp[Args] {
+
+  val forms = List(
+    "geocoding_metadata",
+    "census_variables",
+    "pollutant_variables",
+    "temperature_and_precipitation_variables",
+    "walkability_variables"
+  )
+
+  // Magic marker for "completed".
+  // NB: We are looking for baseline_complete -> 2
+  val extractionFilters: List[FilterDirective] = List(
+    FilterDirective("baseline_complete", FilterOps.==, "2")
+  )
+
+  val subdir = "environment"
+  //todo: need to query for all arms and work through arms serially
+  val arm =
+    List("baseline_arm_1", "dec2019_arm_1", "jan2020_arm_1")
+  val fieldList = List("baseline_complete")
+
+  override def pipelineBuilder: PipelineBuilder[Args] =
+    new ExtractionPipelineBuilder(
+      forms,
+      extractionFilters,
+      arm,
+      fieldList,
+      subdir,
+      100,
+      RedCapClient.apply
+    )
+}

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -88,7 +88,7 @@ class ExtractionPipelineBuilder(
         GetRecords(
           ids = ids.getValue.asScala.toList,
           forms = formsForExtraction,
-          // Pull the consent field so we can QC that the filter is working properly.
+          // List of fields to pull out of the data for us to filter on
           fields = fieldList
         )
       }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilder.scala
@@ -27,10 +27,11 @@ object ExtractionPipelineBuilder {
   *   4. Write the downloaded forms to storage
   *
   * @param formsForExtraction List of forms to be pulled from RedCap
-  * @param extractionFilters Map of filters to be applied whenn pulling RedCap
-  *                          data
-  * @param subDir: Sub directory name where data from this pipeline should be
-  *                written
+  * @param extractionFilters  Map of filters to be applied whenn pulling RedCap data
+  * @param arm List of event arms to be pulled from RedCap (optional)
+  * @param fieldList List of event arms to be pulled from RedCap (optional)
+  * @param subDir             : Sub directory name where data from this pipeline should be
+  *                           written
   * @param idBatchSize max number of IDs to include per batch when
   *                    downloading record data
   * @param getClient function that will produce a client which can
@@ -39,10 +40,11 @@ object ExtractionPipelineBuilder {
 class ExtractionPipelineBuilder(
   formsForExtraction: List[String],
   extractionFilters: List[FilterDirective],
-  arm: String,
+  arm: List[String],
+  fieldList: List[String],
   subDir: String,
   idBatchSize: Int,
-  getClient: String => RedCapClient
+  getClient: List[String] => RedCapClient
 ) extends PipelineBuilder[Args]
     with Serializable {
 
@@ -87,7 +89,7 @@ class ExtractionPipelineBuilder(
           ids = ids.getValue.asScala.toList,
           forms = formsForExtraction,
           // Pull the consent field so we can QC that the filter is working properly.
-          fields = List("co_consent")
+          fields = fieldList
         )
       }
 

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -35,7 +35,9 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
   ) // Magic marker for "completed".
 
   val subdir = "hles"
-  val arm = "baseline_arm_1"
+  // Limit to the initial HLE event.
+  val arm = List("baseline_arm_1")
+  val fieldList = List("co_consent")
 
   override def pipelineBuilder: PipelineBuilder[Args] =
     // Use a batch size of 100 because it seems to work well enough.
@@ -44,6 +46,7 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
       forms,
       extractionFilters,
       arm,
+      fieldList,
       subdir,
       100,
       RedCapClient.apply

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/RedCapClient.scala
@@ -40,7 +40,7 @@ object RedCapClient {
   private val timeout = Duration.ofSeconds(60)
 
   /** Construct a client instance backed by the production RedCap instance. */
-  def apply(arm: String): RedCapClient = {
+  def apply(arm: List[String]): RedCapClient = {
     val logger = LoggerFactory.getLogger(getClass)
 
     val client = new OkHttpClient.Builder()
@@ -64,8 +64,6 @@ object RedCapClient {
 
           val formBuilder = new FormBody.Builder()
             .add("token", apiToken)
-            // Limit to the initial HLE event.
-            .add("events[0]", arm)
             // Export individual survey records as JSON.
             .add("content", "record")
             .add("format", "json")
@@ -79,6 +77,10 @@ object RedCapClient {
             // Honestly not sure what these do, haven't seen the need to make them 'true'.
             .add("exportSurveyFields", "false")
             .add("exportDataAccessGroups", "false")
+          // Parameterized arm
+          if (arm.nonEmpty) {
+            formBuilder.add("events", arm.mkString(","))
+          }
 
           ids.zipWithIndex.foreach {
             case (id, i) => formBuilder.add(s"records[$i]", id)

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/ExtractionPipelineBuilderSpec.scala
@@ -12,11 +12,12 @@ object ExtractionPipelineBuilderSpec {
   val token = "pls-let-me-in"
   val start = OffsetDateTime.now()
   val end = start.plusDays(3).plusHours(10).minusSeconds(100)
-  val event = "fake_event_1"
+  val event = List("fake_event_1")
 
   val fakeIds = 1 to 50
   val forms = List("fake_form_1", "fake_form_2")
   val filters = List(FilterDirective("foo", FilterOps.==, "Bar"))
+  val fields = List("co_consent")
 
   val initQuery = GetRecords(
     start = Some(start),
@@ -79,6 +80,7 @@ class ExtractionPipelineBuilderSpec extends PipelineBuilderSpec[Args] {
       forms,
       filters,
       event,
+      fields,
       "",
       idBatchSize = 1,
       getClient = _ => mockClient


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/1287)
This is the second PR in a series to get the DAP environmental data extracted from RedCap.
We are breaking a larger more convoluted PR into smaller pieces and this is the second of that series.

## This PR

-Parameterized "arm" so that it can be passed as an arguent per pipeline ("events" in RedCapClient)
-Parameterized "fieldList" so that it can be passed as an arguent per pipeline ("fields" in RedCapRequest)
-Updated HLES, CSLB and PipelineBuilder unit test to pass newly added arm and fieldList parameters
-Added a new ExtractionPipeline script for Environment