### PR TITLE
Upgrade to ingest-utils 2.1.6 to pull in latest scio

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.5")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.4")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.5")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1392)
`ingest-utils` 2.1.6 pulls in the latest version of scio, we should upgrade.

## This PR
* Bumps the `ingest-utils` version in plugins.sbt
