### PR TITLE
Fix ITs

### DIFF
--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/CslbExtractionPipelineBuilderIntegrationSpec.scala
@@ -60,7 +60,7 @@ class CslbExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
     readMsgs(cslbOutputDir, "records/*.json").foreach { record =>
       CslbExtractionPipeline.extractionFilters
         .find(directive => directive.field == record.read[String]("field_name"))
-        .foreach(expected => record.read[String]("value") shouldBe expected.field)
+        .foreach(expected => record.read[String]("value") shouldBe expected.comparand)
     }
   }
 }

--- a/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/it/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -60,7 +60,7 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
     readMsgs(hlesOutputDir, "records/*.json").foreach { record =>
       HLESurveyExtractionPipeline.extractionFilters
         .find(directive => directive.field == record.read[String]("field_name"))
-        .foreach(expected => record.read[String]("value") shouldBe expected.field)
+        .foreach(expected => record.read[String]("value") shouldBe expected.comparand)
     }
   }
 }

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
@@ -22,6 +22,7 @@ object EnvironmentExtractionPipeline extends ScioApp[Args] {
   )
 
   val subdir = "environment"
+
   //todo: need to query for all arms and work through arms serially
   val arm =
     List("baseline_arm_1", "dec2019_arm_1", "jan2020_arm_1")


### PR DESCRIPTION
## Why
ITs are failing due to a mistake during my refactorings that introduced FilterDirective.

## This PR
* Fixes the assertion in the tests to compare against the filter's comparand (i.e, "2"), not the field name.
