### PR TITLE
Configure fracture condition to allow description via spec field

### DIFF
--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/EnvironmentExtractionPipeline.scala
@@ -22,6 +22,7 @@ object EnvironmentExtractionPipeline extends ScioApp[Args] {
   )
 
   val subdir = "environment"
+
   //todo: need to query for all arms and work through arms serially
   val arm =
     List("baseline_arm_1", "dec2019_arm_1", "jan2020_arm_1")

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/healthcondition/HealthCondition.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/healthcondition/HealthCondition.scala
@@ -382,7 +382,7 @@ object HealthCondition extends LongEnum[HealthCondition] {
   case object DogBite extends HealthCondition(1801L, "Dog bite", Trauma, dx = Some("dogbite"))
   case object AnimalBite extends HealthCondition(1802L, "Bite wound from another animal", Trauma, dx = Some("anibite"))
   case object Fall extends HealthCondition(1803L, "Fall from height", Trauma, dx = Some("fall"))
-  case object Fracture extends HealthCondition(1804L, "Fractured bone", Trauma, dx = Some("frac"))
+  case object Fracture extends HealthCondition(1804L, "Fractured bone", Trauma, dx = Some("frac"), isOther = true)
   case object Head extends HealthCondition(1805L, "Head trauma due to any cause", Trauma, dx = Some("head"))
   case object Car extends HealthCondition(1806L, "Hit by car or other vehicle", Trauma, dx = Some("car"))
   case object Kick extends HealthCondition(1807L, "Kicked by horse or other large animal", Trauma, dx = Some("kick"))

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/HealthTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/HealthTransformationsSpec.scala
@@ -835,6 +835,12 @@ class HealthTransformationsSpec extends AnyFlatSpec with Matchers {
       "hs_dx_trauma_dogbite_year" -> Array("2020"),
       "hs_dx_trauma_dogbite_surg" -> Array("3"),
       "hs_dx_trauma_dogbite_fu" -> Array("1"),
+      "hs_dx_trauma_frac" -> Array("1"),
+      "hs_dx_trauma_frac_month" -> Array("2"),
+      "hs_dx_trauma_frac_year" -> Array("2019"),
+      "hs_dx_trauma_frac_surg" -> Array("2"),
+      "hs_dx_trauma_frac_fu" -> Array("1"),
+      "hs_dx_trauma_frac_spec" -> Array("speccity"),
       "hs_dx_trauma_other" -> Array("1"),
       "hs_dx_trauma_other_spec" -> Array("ohno"),
       "hs_dx_trauma_other_month" -> Array("2"),
@@ -856,6 +862,19 @@ class HealthTransformationsSpec extends AnyFlatSpec with Matchers {
         hsDiagnosisYear = Some(2020),
         hsDiagnosisMonth = Some(2),
         hsRequiredSurgeryOrHospitalization = Some(3),
+        hsFollowUpOngoing = Some(true)
+      ),
+      HlesHealthCondition(
+        dogId = 1L,
+        hsConditionType = HealthConditionType.Trauma.value,
+        hsCondition = HealthCondition.Fracture.value,
+        hsConditionOtherDescription = Some("speccity"),
+        hsConditionIsCongenital = false,
+        hsConditionCause = None,
+        hsConditionCauseOtherDescription = None,
+        hsDiagnosisYear = Some(2019),
+        hsDiagnosisMonth = Some(2),
+        hsRequiredSurgeryOrHospitalization = Some(2),
         hsFollowUpOngoing = Some(true)
       ),
       HlesHealthCondition(


### PR DESCRIPTION
## Why

Fracture field is a checkbox, and has an optional description field to describe the nature of the fracture, which we had not been pulling in. This PR properly configures the field to pull in the spec field.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1330)

## This PR