### PR TITLE
Update RC variable being queried for stuffed toys

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
@@ -217,7 +217,7 @@ object RoutineEnvironmentTransformations {
       dog.copy(
         deRoutineToys = toys,
         deRoutineToysIncludePlastic = rawRecord.getOptionalNumber("de_toy_plastic"),
-        deRoutineToysIncludeStuffedFabric = rawRecord.getOptionalNumber("de_toy_stuffed_fabric"),
+        deRoutineToysIncludeStuffedFabric = rawRecord.getOptionalNumber("de_toy_fabric_stuffed"),
         deRoutineToysIncludeUnstuffedFabric =
           rawRecord.getOptionalNumber("de_toy_fabric_unstuffed"),
         deRoutineToysIncludeRubber = rawRecord.getOptionalNumber("de_toy_rubber"),


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1394)
DAP team noticed this field didn't have the correct value labels.
When I went to double check the transformation code I noticed we weren't even pulling the field out properly.

## This PR
-Updated the variable name being queried from a RawRecord to something that actually exists in RC.
