### PR TITLE
Add flag to parse and truncate floating point decimals in numeric field values

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
@@ -29,4 +29,3 @@ class HLESurveyTransformationError(msg: String) extends HLESurveyTransformationL
 // case classes for all the different actual warnings and errors we want to raise during the workflow
 case class MissingOwnerIdError(msg: String) extends HLESurveyTransformationError(msg)
 case class TruncatedDecimalError(msg: String) extends HLESurveyTransformationError(msg)
-

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HLESurveyTransformationLog.scala
@@ -28,3 +28,5 @@ class HLESurveyTransformationError(msg: String) extends HLESurveyTransformationL
 
 // case classes for all the different actual warnings and errors we want to raise during the workflow
 case class MissingOwnerIdError(msg: String) extends HLESurveyTransformationError(msg)
+case class TruncatedDecimalError(msg: String) extends HLESurveyTransformationError(msg)
+

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.monster.dap
 
-import java.lang.NumberFormatException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.monster.dap
 
+import java.lang.NumberFormatException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -54,20 +55,25 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   /** Get the singleton value for an attribute in this record, parsed as a long. */
   def getOptionalNumber(field: String, truncateDecimals: Boolean = true): Option[Long] =
     getOptional(field).map(value => {
-      // we can presume the string represents a positive integer if all of its characters are decimal digits
-      if (truncateDecimals && !value.forall(Character.isDigit)) {
-        val truncatedValue: Long = value.toFloat.toLong
-
-        // don't log this error message until after we've successfully converted the string to a long.
-        // this avoids us logging this message erroneously if we were unable to parse the value,
-        // e.g. because it was garbled nonsense
-        TruncatedDecimalError(
-          s"Record $id has an unexpected decimal value in field $field, truncated to integer"
-        ).log
-
-        truncatedValue
-      } else {
+      try {
         value.toLong
+      } catch {
+        case e: NumberFormatException => {
+          if (truncateDecimals) {
+            val truncatedValue: Long = value.toFloat.toLong
+
+            // don't log this error message until after we've successfully converted the string to a long.
+            // this avoids us logging this message erroneously if we were unable to parse the value,
+            // e.g. because it was garbled nonsense
+            TruncatedDecimalError(
+              s"Record $id has an unexpected decimal value in field $field, truncated to integer"
+            ).log
+
+            truncatedValue
+          } else {
+            throw e
+          }
+        }
       }
     })
 

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -66,7 +66,9 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
             // don't log this error message until after we've successfully converted the string to a long.
             // this avoids us logging this message erroneously if we were unable to parse the value,
             // e.g. because it was garbled nonsense
-            TruncatedDecimalError("Record $id has an unexpected decimal value in field $field, truncated to integer").log
+            TruncatedDecimalError(
+              "Record $id has an unexpected decimal value in field $field, truncated to integer"
+            ).log
 
             truncatedValue
           } else {

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -67,7 +67,7 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
             // this avoids us logging this message erroneously if we were unable to parse the value,
             // e.g. because it was garbled nonsense
             TruncatedDecimalError(
-              "Record $id has an unexpected decimal value in field $field, truncated to integer"
+              s"Record $id has an unexpected decimal value in field $field, truncated to integer"
             ).log
 
             truncatedValue

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -102,7 +102,7 @@ object ResidentialEnvironmentTransformations {
       deHomeTypeOtherDescription = rawRecord.getOptional("he_type_home_other"),
       deHomeConstructionDecade = rawRecord.getOptionalNumber("de_home_age"),
       deHomeYearsLivedIn = rawRecord.getOptionalNumber("de_home_lived_years"),
-      deHomeSquareFootage = rawRecord.getOptionalNumber("de_home_area")
+      deHomeSquareFootage = rawRecord.getOptionalNumber("de_home_area", truncateDecimals = true)
     )
 
   /**

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/DogTransformationsSpec.scala
@@ -30,7 +30,7 @@ class DogTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues
     )
   }
 
-  it should "should not map dog when st_owner_id is missing" in {
+  it should "not map dog when st_owner_id is missing" in {
     val mapped = DogTransformations.mapDog(RawRecord(1, Map()))
     mapped shouldBe None
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -119,6 +119,17 @@ class ResidentialEnvironmentTransformationsSpec
     output.deHomeSquareFootage.value shouldBe 1000
   }
 
+  it should "handle floating points in home area" in {
+    val floatingPointDogField = Map[String, Array[String]](
+      "de_home_area" -> Array("1000.34")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, floatingPointDogField)
+      )
+    output.deHomeSquareFootage.value shouldBe 1000L
+  }
+
   it should "map all heating-related fields" in {
     val exampleDogFields = Map[String, Array[String]](
       "de_primary_heat" -> Array("98"),


### PR DESCRIPTION
## Why

We were getting values in `de_home_area` that included decimal points, which breaks Scala's integer parsing. We confirmed with the DAP team that it's safe to ignore decimal point values for integer fields.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1371)

## This PR

Adds a handler to truncate decimal values to `getOptionalNumber` in the raw record class. This handler can be manually disabled, but defaults to being on for all fields. The handler logs all decimals it finds as it truncates them. It does not swallow any errors other than a floating point value being passed to an integer field.