### PR TITLE
Remove codecov config

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 75%
-        threshold: 5%
-

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformationsSpec.scala
@@ -394,7 +394,7 @@ class RoutineEnvironmentTransformationsSpec extends AnyFlatSpec with Matchers wi
     val example1 = Map[String, Array[String]](
       "de_toys_yn" -> Array("1"),
       "de_toy_plastic" -> Array("1"),
-      "de_toy_stuffed_fabric" -> Array("0"),
+      "de_toy_fabric_stuffed" -> Array("0"),
       "de_toy_fabric_unstuffed" -> Array("1"),
       "de_toy_rubber" -> Array("0"),
       "de_toy_metal" -> Array("1"),
@@ -431,7 +431,7 @@ class RoutineEnvironmentTransformationsSpec extends AnyFlatSpec with Matchers wi
     val example2 = Map[String, Array[String]](
       "de_toys_yn" -> Array("1"),
       "de_toy_plastic" -> Array("0"),
-      "de_toy_stuffed_fabric" -> Array("1"),
+      "de_toy_fabric_stuffed" -> Array("1"),
       "de_toy_fabric_unstuffed" -> Array("0"),
       "de_toy_rubber" -> Array("1"),
       "de_toy_metal" -> Array("0"),


### PR DESCRIPTION
## Why

The code coverage tooling in this project are good for guidance but should not result in a failed check. 

## This PR
* Removes the codecov.yaml file which will revert us to the default codecov behavior, which is to not fail checks.

