### PR TITLE
Remove unneeded comment

### DIFF
--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/Args.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/Args.scala
@@ -20,9 +20,6 @@ case class Args(
   endTime: Option[OffsetDateTime],
   @HelpMessage("Path where extracted JSON should be written")
   outputPrefix: String,
-  /** data dictionary pulls are optional;
-    * the REDCap API is extremely flaky when pulling this data down
-    */
   @HelpMessage("Extract data dictionaries")
   pullDataDictionaries: Boolean
 )


### PR DESCRIPTION
## Why

Scaladoc fails to build during the publish step due to this "unmoored" comment (https://github.com/DataBiosphere/dog-aging-ingest/runs/1652198262)

## This PR
* This comment was redundant so I've opted to just remove it.