### PR TITLE
Remove all zip code fields from transformation code and schema

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -63,7 +63,6 @@ object OwnerTransformations {
               rawRecord.getOptional("oc_address1_division").flatMap {
                 getCensusDivision(_)
               },
-            ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
             ocPrimaryResidenceOwnership = primaryAddressOwnership,
             ocPrimaryResidenceOwnershipOtherDescription =
               if (primaryAddressOwnership.contains(98)) {
@@ -74,9 +73,6 @@ object OwnerTransformations {
             ocSecondaryResidence = secondaryAddress,
             ocSecondaryResidenceState = secondaryAddress.flatMap {
               if (_) rawRecord.getOptional("oc_address2_state") else None
-            },
-            ocSecondaryResidenceZip = secondaryAddress.flatMap {
-              if (_) rawRecord.getOptional("oc_address2_zip") else None
             },
             ocSecondaryResidenceOwnership = secondaryAddressOwnership,
             ocSecondaryResidenceOwnershipOtherDescription =

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -20,9 +20,6 @@ object AdditionalStudiesTransformations {
       fsPrimaryCareVeterinarianState = pcVetConsent.flatMap {
         if (_) rawRecord.getOptional("fs_pcvet_st") else None
       },
-      fsPrimaryCareVeterinarianZip = pcVetConsent.flatMap {
-        if (_) rawRecord.getOptional("fs_pcvet_zip") else None
-      },
       fsFutureStudiesParticipationLikelihood = rawRecord.getOptionalNumber("fs_future_studies"),
       fsPhenotypeVsLifespanParticipationLikelihood = pcVetConsent.flatMap {
         if (_) rawRecord.getOptionalNumber("fs_pc_ppf_lifespan") else None

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -214,8 +214,7 @@ object DemographicsTransformations {
       ddAcquiredSourceOtherDescription =
         if (source.contains(98)) rawRecord.getOptional("dd_acquire_source_other") else None,
       ddAcquiredCountry = country,
-      ddAcquiredState = if (locationKnown) rawRecord.getOptional("dd_acquired_st") else None,
-      ddAcquiredZip = if (locationKnown) rawRecord.getOptional("dd_acquired_zip") else None
+      ddAcquiredState = if (locationKnown) rawRecord.getOptional("dd_acquired_st") else None
     )
   }
 

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
@@ -18,9 +18,8 @@ object DogResidenceTransformations {
     val tertiaryResidences = List.tabulate(tertiaryResidenceCutoff) { i =>
       val prefix = f"dd_2nd_residence_${i + 1}%02d"
       val state = rawRecord.getOptional(s"${prefix}_st")
-      val zip = rawRecord.getOptional(s"${prefix}_zip")
       val weeks = rawRecord.getOptionalNumber(s"${prefix}_time")
-      (state, zip, weeks)
+      (state, weeks)
     }
 
     val primaryOwned = rawRecord.getOptionalNumber("oc_address1_own")
@@ -33,7 +32,6 @@ object DogResidenceTransformations {
       ocPrimaryResidenceCensusDivision = rawRecord.getOptional("oc_address1_division").flatMap {
         OwnerTransformations.getCensusDivision(_)
       },
-      ocPrimaryResidenceZip = rawRecord.getOptional("oc_address1_zip"),
       ocPrimaryResidenceOwnership = primaryOwned,
       ocPrimaryResidenceOwnershipOtherDescription =
         if (primaryOwned.contains(98)) rawRecord.getOptional("oc_address1_own_other") else None,
@@ -43,9 +41,6 @@ object DogResidenceTransformations {
       ocSecondaryResidence = hasSecondaryResidence,
       ocSecondaryResidenceState = hasSecondaryResidence.flatMap {
         if (_) rawRecord.getOptional("oc_address2_state") else None
-      },
-      ocSecondaryResidenceZip = hasSecondaryResidence.flatMap {
-        if (_) rawRecord.getOptional("oc_address2_zip") else None
       },
       ocSecondaryResidenceOwnership = secondaryOwned,
       ocSecondaryResidenceOwnershipOtherDescription = if (secondaryOwned.contains(98)) {
@@ -59,82 +54,56 @@ object DogResidenceTransformations {
       ddAlternateRecentResidenceCount = tertiaryResidenceCount.map(_.toLong),
       ddAlternateRecentResidence1State =
         if (tertiaryResidenceCutoff >= 1) tertiaryResidences(0)._1 else None,
-      ddAlternateRecentResidence1Zip =
-        if (tertiaryResidenceCutoff >= 1) tertiaryResidences(0)._2 else None,
       ddAlternateRecentResidence1Weeks =
-        if (tertiaryResidenceCutoff >= 1) tertiaryResidences(0)._3 else None,
+        if (tertiaryResidenceCutoff >= 1) tertiaryResidences(0)._2 else None,
       ddAlternateRecentResidence2State =
         if (tertiaryResidenceCutoff >= 2) tertiaryResidences(1)._1 else None,
-      ddAlternateRecentResidence2Zip =
-        if (tertiaryResidenceCutoff >= 2) tertiaryResidences(1)._2 else None,
       ddAlternateRecentResidence2Weeks =
-        if (tertiaryResidenceCutoff >= 2) tertiaryResidences(1)._3 else None,
+        if (tertiaryResidenceCutoff >= 2) tertiaryResidences(1)._2 else None,
       ddAlternateRecentResidence3State =
         if (tertiaryResidenceCutoff >= 3) tertiaryResidences(2)._1 else None,
-      ddAlternateRecentResidence3Zip =
-        if (tertiaryResidenceCutoff >= 3) tertiaryResidences(2)._2 else None,
       ddAlternateRecentResidence3Weeks =
-        if (tertiaryResidenceCutoff >= 3) tertiaryResidences(2)._3 else None,
+        if (tertiaryResidenceCutoff >= 3) tertiaryResidences(2)._2 else None,
       ddAlternateRecentResidence4State =
         if (tertiaryResidenceCutoff >= 4) tertiaryResidences(3)._1 else None,
-      ddAlternateRecentResidence4Zip =
-        if (tertiaryResidenceCutoff >= 4) tertiaryResidences(3)._2 else None,
       ddAlternateRecentResidence4Weeks =
-        if (tertiaryResidenceCutoff >= 4) tertiaryResidences(3)._3 else None,
+        if (tertiaryResidenceCutoff >= 4) tertiaryResidences(3)._2 else None,
       ddAlternateRecentResidence5State =
         if (tertiaryResidenceCutoff >= 5) tertiaryResidences(4)._1 else None,
-      ddAlternateRecentResidence5Zip =
-        if (tertiaryResidenceCutoff >= 5) tertiaryResidences(4)._2 else None,
       ddAlternateRecentResidence5Weeks =
-        if (tertiaryResidenceCutoff >= 5) tertiaryResidences(4)._3 else None,
+        if (tertiaryResidenceCutoff >= 5) tertiaryResidences(4)._2 else None,
       ddAlternateRecentResidence6State =
         if (tertiaryResidenceCutoff >= 6) tertiaryResidences(5)._1 else None,
-      ddAlternateRecentResidence6Zip =
-        if (tertiaryResidenceCutoff >= 6) tertiaryResidences(5)._2 else None,
       ddAlternateRecentResidence6Weeks =
-        if (tertiaryResidenceCutoff >= 6) tertiaryResidences(5)._3 else None,
+        if (tertiaryResidenceCutoff >= 6) tertiaryResidences(5)._2 else None,
       ddAlternateRecentResidence7State =
         if (tertiaryResidenceCutoff >= 7) tertiaryResidences(6)._1 else None,
-      ddAlternateRecentResidence7Zip =
-        if (tertiaryResidenceCutoff >= 7) tertiaryResidences(6)._2 else None,
       ddAlternateRecentResidence7Weeks =
-        if (tertiaryResidenceCutoff >= 7) tertiaryResidences(6)._3 else None,
+        if (tertiaryResidenceCutoff >= 7) tertiaryResidences(6)._2 else None,
       ddAlternateRecentResidence8State =
         if (tertiaryResidenceCutoff >= 8) tertiaryResidences(7)._1 else None,
-      ddAlternateRecentResidence8Zip =
-        if (tertiaryResidenceCutoff >= 8) tertiaryResidences(7)._2 else None,
       ddAlternateRecentResidence8Weeks =
-        if (tertiaryResidenceCutoff >= 8) tertiaryResidences(7)._3 else None,
+        if (tertiaryResidenceCutoff >= 8) tertiaryResidences(7)._2 else None,
       ddAlternateRecentResidence9State =
         if (tertiaryResidenceCutoff >= 9) tertiaryResidences(8)._1 else None,
-      ddAlternateRecentResidence9Zip =
-        if (tertiaryResidenceCutoff >= 9) tertiaryResidences(8)._2 else None,
       ddAlternateRecentResidence9Weeks =
-        if (tertiaryResidenceCutoff >= 9) tertiaryResidences(8)._3 else None,
+        if (tertiaryResidenceCutoff >= 9) tertiaryResidences(8)._2 else None,
       ddAlternateRecentResidence10State =
         if (tertiaryResidenceCutoff >= 10) tertiaryResidences(9)._1 else None,
-      ddAlternateRecentResidence10Zip =
-        if (tertiaryResidenceCutoff >= 10) tertiaryResidences(9)._2 else None,
       ddAlternateRecentResidence10Weeks =
-        if (tertiaryResidenceCutoff >= 10) tertiaryResidences(9)._3 else None,
+        if (tertiaryResidenceCutoff >= 10) tertiaryResidences(9)._2 else None,
       ddAlternateRecentResidence11State =
         if (tertiaryResidenceCutoff >= 11) tertiaryResidences(10)._1 else None,
-      ddAlternateRecentResidence11Zip =
-        if (tertiaryResidenceCutoff >= 11) tertiaryResidences(10)._2 else None,
       ddAlternateRecentResidence11Weeks =
-        if (tertiaryResidenceCutoff >= 11) tertiaryResidences(10)._3 else None,
+        if (tertiaryResidenceCutoff >= 11) tertiaryResidences(10)._2 else None,
       ddAlternateRecentResidence12State =
         if (tertiaryResidenceCutoff >= 12) tertiaryResidences(11)._1 else None,
-      ddAlternateRecentResidence12Zip =
-        if (tertiaryResidenceCutoff >= 12) tertiaryResidences(11)._2 else None,
       ddAlternateRecentResidence12Weeks =
-        if (tertiaryResidenceCutoff >= 12) tertiaryResidences(11)._3 else None,
+        if (tertiaryResidenceCutoff >= 12) tertiaryResidences(11)._2 else None,
       ddAlternateRecentResidence13State =
         if (tertiaryResidenceCutoff >= 13) tertiaryResidences(12)._1 else None,
-      ddAlternateRecentResidence13Zip =
-        if (tertiaryResidenceCutoff >= 13) tertiaryResidences(12)._2 else None,
       ddAlternateRecentResidence13Weeks =
-        if (tertiaryResidenceCutoff >= 13) tertiaryResidences(12)._3 else None
+        if (tertiaryResidenceCutoff >= 13) tertiaryResidences(12)._2 else None
     )
   }
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -38,28 +38,11 @@ object ResidentialEnvironmentTransformations {
     rawRecord
       .getOptionalNumber("de_home_nbr")
       .fold(dog.copy(deLifetimeResidenceCount = currentResidenceCount)) { pastResidenceCount =>
-        val pastZipCount =
-          if (pastResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
         val pastCountryCount =
           if (pastResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
 
         dog.copy(
           deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
-          dePastResidenceZipCount = Some(pastZipCount),
-          dePastResidenceZip1 = if (pastZipCount > 1) {
-            rawRecord.getOptional("de_zip_01")
-          } else {
-            rawRecord.getOptional("de_zip_01_only")
-          },
-          dePastResidenceZip2 = if (pastZipCount > 1) rawRecord.getOptional("de_zip_02") else None,
-          dePastResidenceZip3 = if (pastZipCount > 2) rawRecord.getOptional("de_zip_03") else None,
-          dePastResidenceZip4 = if (pastZipCount > 3) rawRecord.getOptional("de_zip_04") else None,
-          dePastResidenceZip5 = if (pastZipCount > 4) rawRecord.getOptional("de_zip_05") else None,
-          dePastResidenceZip6 = if (pastZipCount > 5) rawRecord.getOptional("de_zip_06") else None,
-          dePastResidenceZip7 = if (pastZipCount > 6) rawRecord.getOptional("de_zip_07") else None,
-          dePastResidenceZip8 = if (pastZipCount > 7) rawRecord.getOptional("de_zip_08") else None,
-          dePastResidenceZip9 = if (pastZipCount > 8) rawRecord.getOptional("de_zip_09") else None,
-          dePastResidenceZip10 = if (pastZipCount > 9) rawRecord.getOptional("de_zip_10") else None,
           dePastResidenceCountryCount = Some(pastCountryCount),
           dePastResidenceCountry1 = if (pastCountryCount > 1) {
             rawRecord.getOptional("de_country_01")

--- a/hles/transformation/src/test/resources/org/broadinstitute/monster/dap/blank_st_owner_id/records/two_blank_owner_ids_of_three_records.json
+++ b/hles/transformation/src/test/resources/org/broadinstitute/monster/dap/blank_st_owner_id/records/two_blank_owner_ids_of_three_records.json
@@ -1,6 +1,5 @@
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"study_id","value":"11111"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"ss_id","value":"22222"}
-{"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"ss_zip","value":"00000"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"ss_num_people_hh","value":"4"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"ss_num_dogs_hh","value":"2"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"ss_dog_pure_or_mixed","value":"1"}
@@ -35,7 +34,6 @@
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_children_household","value":"1"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_city","value":"Placezone"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_state","value":"XX"}
-{"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_zip","value":"00000"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_mail_address_yn","value":"1"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_own","value":"98"}
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"oc_address2_yn","value":"0"}
@@ -494,7 +492,6 @@
 {"record":"11111","redcap_event_name":"baseline_arm_1","field_name":"st_vemr_possible","value":"0"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"study_id","value":"22222"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"ss_id","value":"101010"}
-{"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"ss_zip","value":"12300"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"ss_num_people_hh","value":"2"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"ss_num_dogs_hh","value":"1"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"ss_dog_pure_or_mixed","value":"1"}
@@ -529,7 +526,6 @@
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_timer_5","value":"39.77"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_city","value":"Placeopolis"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_state","value":"ZZ"}
-{"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_zip","value":"12300"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_mail_address_yn","value":"1"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_own","value":"2"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"oc_address2_yn","value":"0"}
@@ -565,7 +561,6 @@
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_acquired_address","value":"0001 Cemetery Lane"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_acquired_city","value":"Atlantis"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_acquired_st","value":"OC"}
-{"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_acquired_zip","value":"55000"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_timer_9","value":"244.2"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_activities","value":"1"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"dd_timer_8","value":"39.35"}
@@ -968,7 +963,6 @@
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_street1","value":"3704 Literally In Space"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_city","value":"Placeopolis"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_st","value":"ZZ"}
-{"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_zip","value":"12300"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_email_yn","value":"1"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_timer_4","value":"579.3"}
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"fs_gene_lifespan","value":"2"}
@@ -984,7 +978,6 @@
 {"record":"22222","redcap_event_name":"baseline_arm_1","field_name":"st_vemr_date_due","value":"2020-12-31"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"study_id","value":"33333"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"ss_id","value":"129675"}
-{"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"ss_zip","value":"00000"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"ss_num_people_hh","value":"1"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"ss_num_dogs_hh","value":"2"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"ss_dog_pure_or_mixed","value":"1"}
@@ -1015,7 +1008,6 @@
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_timer_5","value":"25.33"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_city","value":"Horrorzone"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_state","value":"XM"}
-{"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_zip","value":"76543"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_mail_address_yn","value":"1"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_address1_own","value":"2"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"oc_address2_yn","value":"0"}
@@ -1458,7 +1450,6 @@
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_street1","value":"96 Hellville Blvd"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_city","value":"Hell"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_st","value":"AA"}
-{"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_zip","value":"99999"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_pcvet_email_yn","value":"7"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_timer_4","value":"254.9"}
 {"record":"33333","redcap_event_name":"baseline_arm_1","field_name":"fs_gene_lifespan","value":"1"}

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -22,12 +22,10 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     "ss_num_dogs_hh" -> Array("2"),
     "oc_address1_state" -> Array("OH"),
     "oc_address1_division" -> Array("Division 3: East North Central"),
-    "oc_address1_zip" -> Array("32837-4949"),
     "oc_address1_own" -> Array("98"),
     "oc_address1_own_other" -> Array("some text"),
     "oc_address2_yn" -> Array("1"),
     "oc_address2_state" -> Array("MA"),
-    "oc_address2_zip" -> Array("02222"),
     "oc_address2_own" -> Array("98"),
     "oc_address2_own_other" -> Array("some text")
   )
@@ -62,12 +60,10 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
           // residence fields
           ocPrimaryResidenceState = Some("OH"),
           ocPrimaryResidenceCensusDivision = Some(3),
-          ocPrimaryResidenceZip = Some("32837-4949"),
           ocPrimaryResidenceOwnership = Some(98),
           ocPrimaryResidenceOwnershipOtherDescription = Some("some text"),
           ocSecondaryResidence = Some(true),
           ocSecondaryResidenceState = Some("MA"),
-          ocSecondaryResidenceZip = Some("02222"),
           ocSecondaryResidenceOwnership = Some(98),
           ocSecondaryResidenceOwnershipOtherDescription = Some("some text")
         )
@@ -85,7 +81,6 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
       case None => FailedStatus
       case Some(owner) =>
         owner.ocSecondaryResidenceState shouldBe None
-        owner.ocSecondaryResidenceZip shouldBe None
         owner.ocSecondaryResidenceOwnership shouldBe None
         owner.ocSecondaryResidenceOwnershipOtherDescription shouldBe None
     }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -15,7 +15,6 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
       "fs_pcvet_consent" -> Array("1"),
       "fs_pcvet_email_yn" -> Array("1"),
       "fs_pcvet_st" -> Array("MA"),
-      "fs_pcvet_zip" -> Array("02062-4444"),
       "fs_future_studies" -> Array("88"),
       "fs_pc_ppf_lifespan" -> Array("87"),
       "fs_gene_lifespan" -> Array("86"),
@@ -31,7 +30,6 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     hasConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe true
     hasConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe true
     hasConsentOut.fsPrimaryCareVeterinarianState.value shouldBe "MA"
-    hasConsentOut.fsPrimaryCareVeterinarianZip.value shouldBe "02062-4444"
     hasConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 88L
     hasConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe 87L
     hasConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe 86L
@@ -44,7 +42,6 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
       "fs_pcvet_consent" -> Array("2"),
       "fs_pcvet_email_yn" -> Array("1"),
       "fs_pcvet_st" -> Array("MA"),
-      "fs_pcvet_zip" -> Array("02062-4444"),
       "fs_future_studies" -> Array("3"),
       "fs_pc_ppf_lifespan" -> Array("2"),
       "fs_gene_lifespan" -> Array("5"),
@@ -60,7 +57,6 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     lacksConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe false
     lacksConsentOut.fsPrimaryCareVeterinarianCanProvideEmail shouldBe None
     lacksConsentOut.fsPrimaryCareVeterinarianState shouldBe None
-    lacksConsentOut.fsPrimaryCareVeterinarianZip shouldBe None
     lacksConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 3L
     lacksConsentOut.fsPhenotypeVsLifespanParticipationLikelihood shouldBe None
     lacksConsentOut.fsGenotypeVsLifespanParticipationLikelihood shouldBe None

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -408,7 +408,6 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_us_born" -> Array("1"),
       "dd_acquired_location_yn" -> Array("1"),
       "dd_acquired_st" -> Array("OH"),
-      "dd_acquired_zip" -> Array("44657"),
       "dd_acquire_source" -> Array("2")
     )
     val international = Map[String, Array[String]](
@@ -439,7 +438,6 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
 
     usBornOut.ddAcquiredCountry.value shouldBe "US"
     usBornOut.ddAcquiredState.value shouldBe "OH"
-    usBornOut.ddAcquiredZip.value shouldBe "44657"
     usBornOut.ddAcquiredSource.value shouldBe 2L
 
     internationalOut.ddAcquiredCountry.value shouldBe "UK"
@@ -447,7 +445,6 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
 
     unknownOut.ddAcquiredCountry.value shouldBe "99"
     unknownOut.ddAcquiredState shouldBe None
-    unknownOut.ddAcquiredZip shouldBe None
     unknownOut.ddAcquiredSource.value shouldBe 98L
     unknownOut.ddAcquiredSourceOtherDescription.value shouldBe "?????"
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
@@ -13,7 +13,6 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "oc_address2_yn" -> Array("0"),
       "dd_2nd_residence_yn" -> Array("0"),
       "oc_address1_state" -> Array("MA"),
-      "oc_address1_zip" -> Array("02114"),
       "oc_address1_own" -> Array("98"),
       "oc_address1_own_other" -> Array("Squatter's rights"),
       "oc_address1_pct" -> Array("2")
@@ -21,7 +20,6 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
 
     val oneAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, oneAddress))
     oneAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
-    oneAddrOut.ocPrimaryResidenceZip.value shouldBe "02114"
     oneAddrOut.ocPrimaryResidenceOwnership.value shouldBe 98L
     oneAddrOut.ocPrimaryResidenceOwnershipOtherDescription.value shouldBe "Squatter's rights"
     // Not a typo: Time percentage not carried forward if only 1 address.
@@ -36,47 +34,37 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_2nd_residence_nbr" -> Array("2"),
       "oc_address1_state" -> Array("MA"),
       "oc_address1_division" -> Array("Division 33: East North Central"),
-      "oc_address1_zip" -> Array("02114"),
       "oc_address1_own" -> Array("1"),
       "oc_address1_pct" -> Array("1"),
       "oc_address2_state" -> Array("MA"),
-      "oc_address2_zip" -> Array("02115"),
       "oc_address2_own" -> Array("98"),
       "oc_address2_own_other" -> Array("Foo"),
       "oc_2nd_address_pct" -> Array("3"),
       "dd_2nd_residence_01_st" -> Array("NH"),
-      "dd_2nd_residence_01_zip" -> Array("00000"),
       "dd_2nd_residence_01_time" -> Array("1"),
       "dd_2nd_residence_02_st" -> Array("VT"),
-      "dd_2nd_residence_02_zip" -> Array("00001"),
       "dd_2nd_residence_02_time" -> Array("2"),
       "dd_2nd_residence_03_st" -> Array("CA"),
-      "dd_2nd_residence_03_zip" -> Array("99999"),
       "dd_2nd_residence_03_time" -> Array("3")
     )
 
     val manyAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, manyAddresses))
     manyAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
     manyAddrOut.ocPrimaryResidenceCensusDivision.value shouldBe 33L
-    manyAddrOut.ocPrimaryResidenceZip.value shouldBe "02114"
     manyAddrOut.ocPrimaryResidenceOwnership.value shouldBe 1L
     manyAddrOut.ocPrimaryResidenceTimePercentage.value shouldBe 1L
     manyAddrOut.ocSecondaryResidence.value shouldBe true
     manyAddrOut.ocSecondaryResidenceState.value shouldBe "MA"
-    manyAddrOut.ocSecondaryResidenceZip.value shouldBe "02115"
     manyAddrOut.ocSecondaryResidenceOwnership.value shouldBe 98L
     manyAddrOut.ocSecondaryResidenceOwnershipOtherDescription.value shouldBe "Foo"
     manyAddrOut.ocSecondaryResidenceTimePercentage.value shouldBe 3L
     manyAddrOut.ddAlternateRecentResidence1State.value shouldBe "NH"
-    manyAddrOut.ddAlternateRecentResidence1Zip.value shouldBe "00000"
     manyAddrOut.ddAlternateRecentResidence1Weeks.value shouldBe 1L
     manyAddrOut.ddAlternateRecentResidence2State.value shouldBe "VT"
-    manyAddrOut.ddAlternateRecentResidence2Zip.value shouldBe "00001"
     manyAddrOut.ddAlternateRecentResidence2Weeks.value shouldBe 2L
     // The data says there are only 2 alternate residences, so the data for
     // the 3rd should not carry forward.
     manyAddrOut.ddAlternateRecentResidence3State shouldBe None
-    manyAddrOut.ddAlternateRecentResidence3Zip shouldBe None
     manyAddrOut.ddAlternateRecentResidence3Weeks shouldBe None
   }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -15,18 +15,6 @@ class ResidentialEnvironmentTransformationsSpec
     val exampleDogFields = Map[String, Array[String]](
       "de_home_nbr" -> Array("10"),
       "oc_address2_yn" -> Array("1"),
-      "de_zip_nbr" -> Array("10"),
-      "de_zip_01_only" -> Array("this should be ignored"),
-      "de_zip_01" -> Array("11111"),
-      "de_zip_02" -> Array("22222"),
-      "de_zip_03" -> Array("33333"),
-      "de_zip_04" -> Array("44444"),
-      "de_zip_05" -> Array("55555"),
-      "de_zip_06" -> Array("66666"),
-      "de_zip_07" -> Array("77777"),
-      "de_zip_08" -> Array("88888"),
-      "de_zip_09" -> Array("99999"),
-      "de_zip_10" -> Array("10101"),
       "de_country_nbr" -> Array("10"),
       "de_country_01_only" -> Array("this should be ignored too"),
       "de_country_01" -> Array("country1"),
@@ -46,17 +34,6 @@ class ResidentialEnvironmentTransformationsSpec
       )
 
     output.deLifetimeResidenceCount.value shouldBe 12
-    output.dePastResidenceZipCount.value shouldBe 10
-    output.dePastResidenceZip1.value shouldBe "11111"
-    output.dePastResidenceZip2.value shouldBe "22222"
-    output.dePastResidenceZip3.value shouldBe "33333"
-    output.dePastResidenceZip4.value shouldBe "44444"
-    output.dePastResidenceZip5.value shouldBe "55555"
-    output.dePastResidenceZip6.value shouldBe "66666"
-    output.dePastResidenceZip7.value shouldBe "77777"
-    output.dePastResidenceZip8.value shouldBe "88888"
-    output.dePastResidenceZip9.value shouldBe "99999"
-    output.dePastResidenceZip10.value shouldBe "10101"
     output.dePastResidenceCountryCount.value shouldBe 10
     output.dePastResidenceCountry1.value shouldBe "country1"
     output.dePastResidenceCountry2.value shouldBe "country2"
@@ -74,10 +51,6 @@ class ResidentialEnvironmentTransformationsSpec
     val exampleDogFields = Map[String, Array[String]](
       "de_home_nbr" -> Array("1"),
       "oc_address2_yn" -> Array("0"),
-      "de_zip_nbr" -> Array("1"),
-      "de_zip_01_only" -> Array("12345"),
-      "de_zip_01" -> Array("ignoredZip1"),
-      "de_zip_01" -> Array("ignoredZip2"),
       "de_country_nbr" -> Array("1"),
       "de_country_01_only" -> Array("USA!"),
       "de_country_01" -> Array("this should be ignored"),
@@ -89,9 +62,6 @@ class ResidentialEnvironmentTransformationsSpec
       )
 
     output.deLifetimeResidenceCount.value shouldBe 2
-    output.dePastResidenceZipCount.value shouldBe 1
-    output.dePastResidenceZip1.value shouldBe "12345"
-    output.dePastResidenceZip2 shouldBe None
     output.dePastResidenceCountryCount.value shouldBe 1
     output.dePastResidenceCountry1.value shouldBe "USA!"
     output.dePastResidenceCountry2 shouldBe None

--- a/schema/src/main/jade-fragments/hles_dog_demographics.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_demographics.fragment.json
@@ -173,10 +173,6 @@
       "datatype": "string"
     },
     {
-      "name": "dd_acquired_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_activities_companion_animal",
       "datatype": "integer"
     },

--- a/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
@@ -1,39 +1,35 @@
 {
   "name": "hles_dog_future_studies",
   "columns": [
-    { 
+    {
       "name": "fs_primary_care_veterinarian_exists",
       "datatype": "boolean"
     },
-    { 
+    {
       "name": "fs_primary_care_veterinarian_consent_share_vemr",
       "datatype": "boolean"
     },
-    { 
+    {
       "name": "fs_primary_care_veterinarian_can_provide_email",
       "datatype": "boolean"
     },
-    { 
+    {
       "name": "fs_primary_care_veterinarian_state",
       "datatype": "string"
     },
-    { 
-      "name": "fs_primary_care_veterinarian_zip",
-      "datatype": "string"
-    },
-    { 
+    {
       "name": "fs_future_studies_participation_likelihood",
       "datatype": "integer"
     },
-    { 
+    {
       "name": "fs_phenotype_vs_lifespan_participation_likelihood",
       "datatype": "integer"
     },
-    { 
+    {
       "name": "fs_genotype_vs_lifespan_participation_likelihood",
       "datatype": "integer"
     },
-    { 
+    {
       "name": "fs_medically_slowed_aging_participation_likelihood",
       "datatype": "integer"
     }

--- a/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
@@ -10,10 +10,6 @@
       "datatype": "integer"
     },
     {
-      "name": "oc_primary_residence_zip",
-      "datatype": "string"
-    },
-    {
       "name": "oc_primary_residence_ownership",
       "datatype": "integer"
     },
@@ -31,10 +27,6 @@
     },
     {
       "name": "oc_secondary_residence_state",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_secondary_residence_zip",
       "datatype": "string"
     },
     {
@@ -58,19 +50,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence1_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence1_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence2_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence2_zip",
       "datatype": "string"
     },
     {
@@ -82,19 +66,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence3_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence3_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence4_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence4_zip",
       "datatype": "string"
     },
     {
@@ -106,19 +82,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence5_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence5_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence6_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence6_zip",
       "datatype": "string"
     },
     {
@@ -130,19 +98,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence7_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence7_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence8_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence8_zip",
       "datatype": "string"
     },
     {
@@ -154,19 +114,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence9_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence9_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence10_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence10_zip",
       "datatype": "string"
     },
     {
@@ -178,10 +130,6 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence11_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence11_weeks",
       "datatype": "integer"
     },
@@ -190,19 +138,11 @@
       "datatype": "string"
     },
     {
-      "name": "dd_alternate_recent_residence12_zip",
-      "datatype": "string"
-    },
-    {
       "name": "dd_alternate_recent_residence12_weeks",
       "datatype": "integer"
     },
     {
       "name": "dd_alternate_recent_residence13_state",
-      "datatype": "string"
-    },
-    {
-      "name": "dd_alternate_recent_residence13_zip",
       "datatype": "string"
     },
     {

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -6,50 +6,6 @@
       "datatype": "integer"
     },
     {
-      "name": "de_past_residence_zip_count",
-      "datatype": "integer"
-    },
-    {
-      "name": "de_past_residence_zip1",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip2",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip3",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip4",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip5",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip6",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip7",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip8",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip9",
-      "datatype": "string"
-    },
-    {
-      "name": "de_past_residence_zip10",
-      "datatype": "string"
-    },
-    {
       "name": "de_past_residence_country_count",
       "datatype": "integer"
     },

--- a/schema/src/main/jade-tables/hles_owner.table.json
+++ b/schema/src/main/jade-tables/hles_owner.table.json
@@ -83,10 +83,6 @@
       "datatype": "integer"
     },
     {
-      "name": "oc_primary_residence_zip",
-      "datatype": "string"
-    },
-    {
       "name": "oc_primary_residence_ownership",
       "datatype": "integer"
     },
@@ -100,10 +96,6 @@
     },
     {
       "name": "oc_secondary_residence_state",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_secondary_residence_zip",
       "datatype": "string"
     },
     {


### PR DESCRIPTION
There should be no remaining references to ZIP codes in our code. A full refresh will be necessary to remove existing data from our databases.

## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1398)

The Redcap team has some privacy concerns about controlling access to ZIP code information, and since the level of granular control they need isn't currently available, they've asked us to simply remove all such fields from our tables and stop processing them in our transformations.

## This PR