### PR TITLE
Strip newlines from cslb_other_changes

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CslbTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CslbTransformations.scala
@@ -25,7 +25,7 @@ object CslbTransformations {
             cslbRecognize6mo = rawRecord.getOptionalNumber("cslb_recognize_6mo"),
             cslbActive6mo = rawRecord.getOptionalNumber("cslb_active_6mo"),
             cslbScore = rawRecord.getOptionalNumber("cslb_score"),
-            cslbOtherChanges = rawRecord.getOptional("cslb_other_changes")
+            cslbOtherChanges = rawRecord.getOptional("cslb_other_changes", stripNewlines = true)
           )
         )
       case _ =>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CslbTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CslbTransformations.scala
@@ -25,7 +25,7 @@ object CslbTransformations {
             cslbRecognize6mo = rawRecord.getOptionalNumber("cslb_recognize_6mo"),
             cslbActive6mo = rawRecord.getOptionalNumber("cslb_active_6mo"),
             cslbScore = rawRecord.getOptionalNumber("cslb_score"),
-            cslbOtherChanges = rawRecord.getOptional("cslb_other_changes", stripNewlines = true)
+            cslbOtherChanges = rawRecord.getOptionalStripped("cslb_other_changes")
           )
         )
       case _ =>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -37,12 +37,19 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     *
     * Raises an error if the attribute has multiple values.
     */
-  def getOptional(field: String): Option[String] = {
+  def getOptional(field: String, stripNewlines: Boolean = false): Option[String] = {
     val values = fields.getOrElse(field, Array.empty)
     if (values.length > 1) {
       throw new IllegalStateException(s"Record $id has multiple values for field $field")
     } else {
-      values.headOption
+      if (stripNewlines) {
+        values.headOption match {
+          case Some(value) => Some(value.replace('\n', ' '))
+          case None        => None
+        }
+      } else {
+        values.headOption
+      }
     }
   }
 

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -37,20 +37,17 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     *
     * Raises an error if the attribute has multiple values.
     */
-  def getOptional(field: String, stripNewlines: Boolean = false): Option[String] = {
+  def getOptional(field: String): Option[String] = {
     val values = fields.getOrElse(field, Array.empty)
     if (values.length > 1) {
       throw new IllegalStateException(s"Record $id has multiple values for field $field")
     } else {
-      if (stripNewlines) {
-        values.headOption match {
-          case Some(value) => Some(value.replace('\n', ' '))
-          case None        => None
-        }
-      } else {
-        values.headOption
-      }
+      values.headOption
     }
+  }
+
+  def getOptionalStripped(field: String): Option[String] = {
+    getOptional(field).map(_.replace('\n', ' '))
   }
 
   /** Get the singleton value for an attribute in this record, parsed as a boolean. */

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
@@ -30,6 +30,17 @@ class CslbTransformationSpec extends AnyFlatSpec {
     "cslb_other_changes" -> Array("No new changes")
   )
 
+  it should "strip unwanted newlines from cslb_other_changes" in {
+    val exampleCslbRecord = RawRecord(
+      id = 1,
+      exampleCslbFields.updated("cslb_other_changes", Array("this is some text\nwith a line break"))
+    )
+
+    val output = CslbTransformations.mapCslbData(exampleCslbRecord).get
+
+    output.cslbOtherChanges shouldBe Some("this is some text with a line break")
+  }
+
   it should "return None when not processing a cslb record" in {
     val exampleNonCslbRecord = RawRecord(id = 1, Map("foo" -> Array("Bar")))
     val output = CslbTransformations.mapCslbData(exampleNonCslbRecord)


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1427)
Newlines in the `cslb_other_changes` field is causing issues with parsing by downstream systems. After an offline discussion, it's been determined that stripping the newlines will work for this field.

## This PR
* Adds a method to rawrecord that will return an `Option[String]` with newlines removed

