### PR TITLE
Strip DOS and UNIX carriage returns

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -62,7 +62,7 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   }
 
   def getOptionalStripped(field: String): Option[String] = {
-    getOptional(field).map(_.replace("\r\n", " "))
+    getOptional(field).map(_.replaceAll("\r?\n", " "))
   }
 
   /** Get the singleton value for an attribute in this record, parsed as a boolean. */

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -62,7 +62,7 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   }
 
   def getOptionalStripped(field: String): Option[String] = {
-    getOptional(field).map(_.replace('\n', ' '))
+    getOptional(field).map(_.replace("\r\n", " "))
   }
 
   /** Get the singleton value for an attribute in this record, parsed as a boolean. */

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
@@ -30,15 +30,20 @@ class CslbTransformationSpec extends AnyFlatSpec {
     "cslb_other_changes" -> Array("No new changes")
   )
 
-  it should "strip unwanted newlines from cslb_other_changes" in {
+  it should "strip unwanted DOS and unix newlines from cslb_other_changes" in {
     val exampleCslbRecord = RawRecord(
       id = 1,
-      exampleCslbFields.updated("cslb_other_changes", Array("this is some text\r\nwith a line break"))
+      exampleCslbFields.updated(
+        "cslb_other_changes",
+        Array("this is some text\r\nwith a DOS line break\nand a unix line break")
+      )
     )
 
     val output = CslbTransformations.mapCslbData(exampleCslbRecord).get
 
-    output.cslbOtherChanges shouldBe Some("this is some text with a line break")
+    output.cslbOtherChanges shouldBe Some(
+      "this is some text with a DOS line break and a unix line break"
+    )
   }
 
   it should "return None when not processing a cslb record" in {

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/CslbTransformationSpec.scala
@@ -33,7 +33,7 @@ class CslbTransformationSpec extends AnyFlatSpec {
   it should "strip unwanted newlines from cslb_other_changes" in {
     val exampleCslbRecord = RawRecord(
       id = 1,
-      exampleCslbFields.updated("cslb_other_changes", Array("this is some text\nwith a line break"))
+      exampleCslbFields.updated("cslb_other_changes", Array("this is some text\r\nwith a line break"))
     )
 
     val output = CslbTransformations.mapCslbData(exampleCslbRecord).get


### PR DESCRIPTION
## Why

In running through the cslb transform, I noticed we're still not removing offending newlines correctly. We need to strip DOS new lines (\r\n), not UNIX (\n). 

## This PR
* Changes the newline we replace to the DOS version (\r\n)
