### PR TITLE
Limit HLES results to those from before 2021

### DIFF
--- a/hack/manual_refresh.sh
+++ b/hack/manual_refresh.sh
@@ -30,11 +30,11 @@ env_automation=$(vault read -field=token secret/dsde/monster/${ENV}/dog-aging/re
 
 # EXTRACTION
 #   HLES
-sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.HLESurveyExtractionPipeline --apiToken=$automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh/raw --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service"
+sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.HLESurveyExtractionPipeline --apiToken=$automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh/raw --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service --endTime 2020-12-31T23:59:59-05:00"
 #   CSLB
-sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.CslbExtractionPipeline --apiToken=$automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service"
+sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.CslbExtractionPipeline --apiToken=$automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service --endTime 2020-12-31T23:59:59-05:00"
 #   ENVIRONMENT
-sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.EnvironmentExtractionPipeline --apiToken=$env_automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service"
+sbt "dog-aging-hles-extraction/runMain org.broadinstitute.monster.dap.EnvironmentExtractionPipeline --apiToken=$env_automation --pullDataDictionaries=false --outputPrefix=gs://broad-dsp-monster-dap-dev-storage/weekly_refresh --runner=dataflow --project=broad-dsp-monster-dap-dev --region=us-central1 --workerMachineType=n1-standard-1 --autoscalingAlgorithm=THROUGHPUT_BASED --numWorkers=4 --maxNumWorkers=8 --experiments=shuffle_mode=service --endTime 2020-12-31T23:59:59-05:00"
 
 # TRANSFORMATION
 #   HLES

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/FilterDirective.scala
@@ -13,6 +13,10 @@ object FilterOps {
   case object > extends FilterOp {
     def op: String = ">"
   }
+
+  case object < extends FilterOp {
+    def op: String = "<"
+  }
 }
 
 /**

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -31,8 +31,7 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
     .map(form => FilterDirective(s"${form}_complete", FilterOps.==, "2")) ++ List(
     FilterDirective("co_consent", FilterOps.==, "1"),
     FilterDirective("st_dap_pack_count", FilterOps.>, "0"),
-    FilterDirective("st_dap_pack_date", FilterOps.>, HLESEpoch),
-    FilterDirective("st_dap_pack_date", FilterOps.<, "2021-01-01")
+    FilterDirective("st_dap_pack_date", FilterOps.>, HLESEpoch)
   ) // Magic marker for "completed".
 
   val subdir = "hles"

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -31,7 +31,7 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
     .map(form => FilterDirective(s"${form}_complete", FilterOps.==, "2")) ++ List(
     FilterDirective("co_consent", FilterOps.==, "1"),
     FilterDirective("st_dap_pack_count", FilterOps.>, "0"),
-    FilterDirective("st_dap_pack_date", FilterOps.>, HLESEpoch)
+    FilterDirective("st_dap_pack_date", FilterOps.>, HLESEpoch),
     FilterDirective("st_dap_pack_date", FilterOps.<, "2021-01-01")
   ) // Magic marker for "completed".
 

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/HLESurveyExtractionPipeline.scala
@@ -32,6 +32,7 @@ object HLESurveyExtractionPipeline extends ScioApp[Args] {
     FilterDirective("co_consent", FilterOps.==, "1"),
     FilterDirective("st_dap_pack_count", FilterOps.>, "0"),
     FilterDirective("st_dap_pack_date", FilterOps.>, HLESEpoch)
+    FilterDirective("st_dap_pack_date", FilterOps.<, "2021-01-01")
   ) // Magic marker for "completed".
 
   val subdir = "hles"

--- a/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/OkWrapper.scala
+++ b/hles/extraction/src/main/scala/org/broadinstitute/monster/dap/OkWrapper.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{Future, Promise}
 
 class OkWrapper extends HttpWrapper {
   /** Timeout to use for all requests to production RedCap. */
-  private val timeout = Duration.ofSeconds(60)
+  private val timeout = Duration.ofSeconds(300)
   private val logger = LoggerFactory.getLogger(getClass)
 
   /** Construct a client instance backed by the production RedCap instance. */


### PR DESCRIPTION
## Why

DAP has asked that the first release be all data from 2020.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1440)

## This PR

* Limit the pack date for records to before 2021