### PR TITLE
Strip newline and tab characters from all free description fields

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CancerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/CancerTransformations.scala
@@ -62,7 +62,7 @@ object CancerTransformations {
           hsCancerLocationsOther = cancerLocations.map(_.contains("98")),
           hsCancerLocationsOtherDescription =
             if (cancerLocations.getOrElse(Array.empty).contains("98")) {
-              rawRecord.getOptional("hs_dx_cancer_loc_other")
+              rawRecord.getOptionalStripped("hs_dx_cancer_loc_other")
             } else {
               None
             },
@@ -103,7 +103,7 @@ object CancerTransformations {
           hsCancerTypesUnknown = cancerTypes.map(_.contains("99")),
           hsCancerTypesOther = cancerTypes.map(_.contains("98")),
           hsCancerTypesOtherDescription = if (cancerTypes.getOrElse(Array.empty).contains("98")) {
-            rawRecord.getOptional("hs_dx_cancer_type_other")
+            rawRecord.getOptionalStripped("hs_dx_cancer_type_other")
           } else {
             None
           },
@@ -113,7 +113,7 @@ object CancerTransformations {
           hsLeukemiaTypesOther = leukemiaTypes.map(_.contains("98")),
           hsLeukemiaTypesOtherDescription =
             if (leukemiaTypes.getOrElse(Array.empty).contains("98")) {
-              rawRecord.getOptional("hs_dx_cancer_leuk_other")
+              rawRecord.getOptionalStripped("hs_dx_cancer_leuk_other")
             } else {
               None
             },
@@ -124,7 +124,7 @@ object CancerTransformations {
           hsLymphomaLymphosarcomaTypesOther = lymphomaTypes.map(_.contains("98")),
           hsLymphomaLymphosarcomaTypesOtherDescription =
             if (lymphomaTypes.getOrElse(Array.empty).contains("98")) {
-              rawRecord.getOptional("hs_dx_cancer_lymph_other")
+              rawRecord.getOptionalStripped("hs_dx_cancer_lymph_other")
             } else {
               None
             }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HealthTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HealthTransformations.scala
@@ -36,7 +36,9 @@ object HealthTransformations {
             val descriptionFieldName = healthCondition.descriptionSuffixOverride
               .map(suffix => s"${cgKey.dataPrefix}_$suffix")
               .getOrElse(s"${prefix}_spec")
-            base.copy(hsConditionOtherDescription = rawRecord.getOptionalStripped(descriptionFieldName))
+            base.copy(hsConditionOtherDescription =
+              rawRecord.getOptionalStripped(descriptionFieldName)
+            )
           } else {
             base
           }
@@ -87,7 +89,9 @@ object HealthTransformations {
               if (isCauseKnown) rawRecord.getOptionalStripped("hs_dx_kidney_ui_fu_why") else None
           )
         } else if (healthCondition == HealthCondition.VestibularDisease) {
-          base.copy(hsConditionCauseOtherDescription = rawRecord.getOptionalStripped("hs_dx_neuro_vd_type"))
+          base.copy(hsConditionCauseOtherDescription =
+            rawRecord.getOptionalStripped("hs_dx_neuro_vd_type")
+          )
         } else if (healthCondition.isOther) {
           val descriptionFieldName = healthCondition.descriptionSuffixOverride
             .map(suffix => s"${dxKey.dataPrefix}_$suffix")

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HealthTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/HealthTransformations.scala
@@ -36,7 +36,7 @@ object HealthTransformations {
             val descriptionFieldName = healthCondition.descriptionSuffixOverride
               .map(suffix => s"${cgKey.dataPrefix}_$suffix")
               .getOrElse(s"${prefix}_spec")
-            base.copy(hsConditionOtherDescription = rawRecord.getOptional(descriptionFieldName))
+            base.copy(hsConditionOtherDescription = rawRecord.getOptionalStripped(descriptionFieldName))
           } else {
             base
           }
@@ -75,7 +75,7 @@ object HealthTransformations {
           base.copy(
             hsConditionCause = conditionCause,
             hsConditionCauseOtherDescription = if (conditionCause.contains(98)) {
-              rawRecord.getOptional("hs_dx_eye_cause_other")
+              rawRecord.getOptionalStripped("hs_dx_eye_cause_other")
             } else {
               None
             }
@@ -84,15 +84,15 @@ object HealthTransformations {
           val isCauseKnown = rawRecord.getBoolean("hs_dx_kidney_ui_fu_cause")
           base.copy(
             hsConditionCauseOtherDescription =
-              if (isCauseKnown) rawRecord.getOptional("hs_dx_kidney_ui_fu_why") else None
+              if (isCauseKnown) rawRecord.getOptionalStripped("hs_dx_kidney_ui_fu_why") else None
           )
         } else if (healthCondition == HealthCondition.VestibularDisease) {
-          base.copy(hsConditionCauseOtherDescription = rawRecord.getOptional("hs_dx_neuro_vd_type"))
+          base.copy(hsConditionCauseOtherDescription = rawRecord.getOptionalStripped("hs_dx_neuro_vd_type"))
         } else if (healthCondition.isOther) {
           val descriptionFieldName = healthCondition.descriptionSuffixOverride
             .map(suffix => s"${dxKey.dataPrefix}_$suffix")
             .getOrElse(s"${prefix}_spec")
-          base.copy(hsConditionOtherDescription = rawRecord.getOptional(descriptionFieldName))
+          base.copy(hsConditionOtherDescription = rawRecord.getOptionalStripped(descriptionFieldName))
         } else {
           base
         }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -50,7 +50,7 @@ object OwnerTransformations {
             odRaceOtherPacificIslander = raceValues.map(_.contains("7")),
             odRaceOther = otherRace,
             odRaceOtherDescription = otherRace.flatMap {
-              if (_) rawRecord.getOptional("od_race_other") else None
+              if (_) rawRecord.getOptionalStripped("od_race_other") else None
             },
             odHispanic = rawRecord.getOptionalBoolean("od_hispanic_yn"),
             odAnnualIncomeRangeUsd = rawRecord.getOptionalNumber("od_income"),
@@ -66,7 +66,7 @@ object OwnerTransformations {
             ocPrimaryResidenceOwnership = primaryAddressOwnership,
             ocPrimaryResidenceOwnershipOtherDescription =
               if (primaryAddressOwnership.contains(98)) {
-                rawRecord.getOptional("oc_address1_own_other")
+                rawRecord.getOptionalStripped("oc_address1_own_other")
               } else {
                 None
               },
@@ -77,7 +77,7 @@ object OwnerTransformations {
             ocSecondaryResidenceOwnership = secondaryAddressOwnership,
             ocSecondaryResidenceOwnershipOtherDescription =
               if (secondaryAddressOwnership.contains(98)) {
-                rawRecord.getOptional("oc_address2_own_other")
+                rawRecord.getOptionalStripped("oc_address2_own_other")
               } else {
                 None
               }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -61,8 +61,11 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     }
   }
 
+  val sequencesToStrip = List("\r?\n", "\t")
   def getOptionalStripped(field: String): Option[String] = {
-    getOptional(field).map(_.replaceAll("\r?\n", " "))
+    getOptional(field).map(fieldValue => sequencesToStrip.fold(fieldValue) {
+      (processedFieldValue, sequence) => processedFieldValue.replaceAll(sequence, " ")
+    }
   }
 
   /** Get the singleton value for an attribute in this record, parsed as a boolean. */

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -62,10 +62,13 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   }
 
   val sequencesToStrip = List("\r?\n", "\t")
+
   def getOptionalStripped(field: String): Option[String] = {
-    getOptional(field).map(fieldValue => sequencesToStrip.fold(fieldValue) {
-      (processedFieldValue, sequence) => processedFieldValue.replaceAll(sequence, " ")
-    }
+    getOptional(field).map(fieldValue =>
+      sequencesToStrip.fold(fieldValue) { (processedFieldValue, sequence) =>
+        processedFieldValue.replaceAll(sequence, " ")
+      }
+    )
   }
 
   /** Get the singleton value for an attribute in this record, parsed as a boolean. */

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -37,7 +37,7 @@ object DemographicsTransformations {
           ddBreedPureOrMixed = breedType,
           ddBreedPure = breed,
           ddBreedPureNonAkc =
-            if (breed.contains(277L)) rawRecord.getOptional("dd_dog_breed_non_akc") else None
+            if (breed.contains(277L)) rawRecord.getOptionalStripped("dd_dog_breed_non_akc") else None
         )
       case Some(2) =>
         dog.copy(
@@ -90,7 +90,7 @@ object DemographicsTransformations {
           ddAgeExactSourceFromLitterOwnerBred = Some(sources.contains("5")),
           ddAgeExactSourceOther = Some(sources.contains("98")),
           ddAgeExactSourceOtherDescription =
-            if (sources.contains("98")) rawRecord.getOptional("dd_dog_age_certain_other") else None,
+            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_certain_other") else None,
           ddBirthYear = Some(birthYear.toLong),
           ddBirthMonthKnown = Some(exactMonthKnown),
           ddBirthMonth = if (exactMonthKnown) Some(birthMonth.toLong) else None
@@ -107,7 +107,7 @@ object DemographicsTransformations {
           ddAgeEstimateSourceDeterminedByVeterinarian = Some(sources.contains("4")),
           ddAgeEstimateSourceOther = Some(sources.contains("98")),
           ddAgeEstimateSourceOtherDescription =
-            if (sources.contains("98")) rawRecord.getOptional("dd_dog_age_estimate_other") else None
+            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_estimate_other") else None
         )
       }
     }
@@ -186,7 +186,7 @@ object DemographicsTransformations {
           ddInsurance = Some(insurance),
           ddInsuranceProvider = provider,
           ddInsuranceProviderOtherDescription =
-            if (provider.contains(98)) rawRecord.getOptional("dd_insurance_other") else None
+            if (provider.contains(98)) rawRecord.getOptionalStripped("dd_insurance_other") else None
         )
       } else {
         dog.copy(ddInsurance = Some(insurance))
@@ -212,7 +212,7 @@ object DemographicsTransformations {
       ddAcquiredMonth = rawRecord.getOptionalNumber("dd_acquire_month"),
       ddAcquiredSource = source,
       ddAcquiredSourceOtherDescription =
-        if (source.contains(98)) rawRecord.getOptional("dd_acquire_source_other") else None,
+        if (source.contains(98)) rawRecord.getOptionalStripped("dd_acquire_source_other") else None,
       ddAcquiredCountry = country,
       ddAcquiredState = if (locationKnown) rawRecord.getOptional("dd_acquired_st") else None
     )
@@ -279,8 +279,8 @@ object DemographicsTransformations {
       ddActivitiesAssistanceOrTherapy = assistanceLevel,
       ddActivitiesOther = otherLevel,
       ddActivitiesOtherDescription = otherLevel.flatMap {
-        case 1L => rawRecord.getOptional("dd_1st_activity_other")
-        case 2L => rawRecord.getOptional("dd_2nd_activity_other")
+        case 1L => rawRecord.getOptionalStripped("dd_1st_activity_other")
+        case 2L => rawRecord.getOptionalStripped("dd_2nd_activity_other")
         case _  => None
       },
       ddActivitiesServiceSeeingEye = serviceTypes.map(_.contains("1")),
@@ -288,17 +288,17 @@ object DemographicsTransformations {
       ddActivitiesServiceWheelchair = serviceTypes.map(_.contains("3")),
       ddActivitiesServiceOtherMedical = otherMedService,
       ddActivitiesServiceOtherMedicalDescription =
-        if (otherMedService.contains(true)) rawRecord.getOptional("dd_service_medical_other_1")
+        if (otherMedService.contains(true)) rawRecord.getOptionalStripped("dd_service_medical_other_1")
         else None,
       ddActivitiesServiceOtherHealth = otherHealthService,
       ddActivitiesServiceOtherHealthDescription =
-        if (otherHealthService.contains(true)) rawRecord.getOptional("dd_service_health_other_1")
+        if (otherHealthService.contains(true)) rawRecord.getOptionalStripped("dd_service_health_other_1")
         else None,
       ddActivitiesServiceCommunityTherapy = serviceTypes.map(_.contains("6")),
       ddActivitiesServiceEmotionalSupport = serviceTypes.map(_.contains("7")),
       ddActivitiesServiceOther = otherService,
       ddActivitiesServiceOtherDescription =
-        if (otherService.contains(true)) rawRecord.getOptional("dd_service_other_1") else None
+        if (otherService.contains(true)) rawRecord.getOptionalStripped("dd_service_other_1") else None
     )
   }
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -37,7 +37,8 @@ object DemographicsTransformations {
           ddBreedPureOrMixed = breedType,
           ddBreedPure = breed,
           ddBreedPureNonAkc =
-            if (breed.contains(277L)) rawRecord.getOptionalStripped("dd_dog_breed_non_akc") else None
+            if (breed.contains(277L)) rawRecord.getOptionalStripped("dd_dog_breed_non_akc")
+            else None
         )
       case Some(2) =>
         dog.copy(
@@ -90,7 +91,8 @@ object DemographicsTransformations {
           ddAgeExactSourceFromLitterOwnerBred = Some(sources.contains("5")),
           ddAgeExactSourceOther = Some(sources.contains("98")),
           ddAgeExactSourceOtherDescription =
-            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_certain_other") else None,
+            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_certain_other")
+            else None,
           ddBirthYear = Some(birthYear.toLong),
           ddBirthMonthKnown = Some(exactMonthKnown),
           ddBirthMonth = if (exactMonthKnown) Some(birthMonth.toLong) else None
@@ -107,7 +109,8 @@ object DemographicsTransformations {
           ddAgeEstimateSourceDeterminedByVeterinarian = Some(sources.contains("4")),
           ddAgeEstimateSourceOther = Some(sources.contains("98")),
           ddAgeEstimateSourceOtherDescription =
-            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_estimate_other") else None
+            if (sources.contains("98")) rawRecord.getOptionalStripped("dd_dog_age_estimate_other")
+            else None
         )
       }
     }
@@ -288,17 +291,20 @@ object DemographicsTransformations {
       ddActivitiesServiceWheelchair = serviceTypes.map(_.contains("3")),
       ddActivitiesServiceOtherMedical = otherMedService,
       ddActivitiesServiceOtherMedicalDescription =
-        if (otherMedService.contains(true)) rawRecord.getOptionalStripped("dd_service_medical_other_1")
+        if (otherMedService.contains(true))
+          rawRecord.getOptionalStripped("dd_service_medical_other_1")
         else None,
       ddActivitiesServiceOtherHealth = otherHealthService,
       ddActivitiesServiceOtherHealthDescription =
-        if (otherHealthService.contains(true)) rawRecord.getOptionalStripped("dd_service_health_other_1")
+        if (otherHealthService.contains(true))
+          rawRecord.getOptionalStripped("dd_service_health_other_1")
         else None,
       ddActivitiesServiceCommunityTherapy = serviceTypes.map(_.contains("6")),
       ddActivitiesServiceEmotionalSupport = serviceTypes.map(_.contains("7")),
       ddActivitiesServiceOther = otherService,
       ddActivitiesServiceOtherDescription =
-        if (otherService.contains(true)) rawRecord.getOptionalStripped("dd_service_other_1") else None
+        if (otherService.contains(true)) rawRecord.getOptionalStripped("dd_service_other_1")
+        else None
     )
   }
 }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
@@ -29,7 +29,7 @@ object DietTransformations {
       dfFeedingsPerDay = rawRecord.getOptionalNumber("df_frequency"),
       dfDietConsistency = consistency,
       dfDietConsistencyOtherDescription = if (consistency.contains(98L)) {
-        rawRecord.getOptional("df_consistent_other")
+        rawRecord.getOptionalStripped("df_consistent_other")
       } else {
         None
       },
@@ -63,7 +63,7 @@ object DietTransformations {
     dog.copy(
       dfPrimaryDietComponent = component,
       dfPrimaryDietComponentOtherDescription = if (component.contains(98L)) {
-        rawRecord.getOptional("df_prim_other")
+        rawRecord.getOptionalStripped("df_prim_other")
       } else {
         None
       },
@@ -82,7 +82,7 @@ object DietTransformations {
       dfPrimaryDietComponentChangeNewFoodSameBrand = changeReasons.map(_.contains("6")),
       dfPrimaryDietComponentChangeOther = changeOther,
       dfPrimaryDietComponentChangeOtherDescription = changeOther.flatMap {
-        if (_) rawRecord.getOptional("df_prim_change_why_other") else None
+        if (_) rawRecord.getOptionalStripped("df_prim_change_why_other") else None
       }
     )
   }
@@ -105,7 +105,7 @@ object DietTransformations {
       dfSecondaryDietComponentUsed = secondaryUsed,
       dfSecondaryDietComponent = component,
       dfSecondaryDietComponentOtherDescription = if (component.contains(98L)) {
-        rawRecord.getOptional("df_sec_other")
+        rawRecord.getOptionalStripped("df_sec_other")
       } else {
         None
       },
@@ -124,7 +124,7 @@ object DietTransformations {
       dfSecondaryDietComponentChangeNewFoodSameBrand = changeReasons.map(_.contains("6")),
       dfSecondaryDietComponentChangeOther = changeOther,
       dfSecondaryDietComponentChangeOtherDescription = changeOther.flatMap {
-        if (_) rawRecord.getOptional("df_sec_change_why_other") else None
+        if (_) rawRecord.getOptionalStripped("df_sec_change_why_other") else None
       }
     )
   }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
@@ -33,7 +33,7 @@ object DogResidenceTransformations {
       },
       ocPrimaryResidenceOwnership = primaryOwned,
       ocPrimaryResidenceOwnershipOtherDescription =
-        if (primaryOwned.contains(98)) rawRecord.getOptional("oc_address1_own_other") else None,
+        if (primaryOwned.contains(98)) rawRecord.getOptionalStripped("oc_address1_own_other") else None,
       ocPrimaryResidenceTimePercentage = hasSecondaryResidence.flatMap {
         if (_) rawRecord.getOptionalNumber("oc_address1_pct") else None
       },

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformations.scala
@@ -33,7 +33,8 @@ object DogResidenceTransformations {
       },
       ocPrimaryResidenceOwnership = primaryOwned,
       ocPrimaryResidenceOwnershipOtherDescription =
-        if (primaryOwned.contains(98)) rawRecord.getOptionalStripped("oc_address1_own_other") else None,
+        if (primaryOwned.contains(98)) rawRecord.getOptionalStripped("oc_address1_own_other")
+        else None,
       ocPrimaryResidenceTimePercentage = hasSecondaryResidence.flatMap {
         if (_) rawRecord.getOptionalNumber("oc_address1_pct") else None
       },

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
@@ -45,11 +45,11 @@ object HealthStatusTransformations {
       hsRecentHospitalizationReasonOther = hospitalizationReasons.map(_.contains("99")),
       hsRecentHospitalizationReasonOtherDescription =
         if (hospitalizationReasons.getOrElse(Array.empty).contains("99")) {
-          rawRecord.getOptional("hs_hosp_why_other")
+          rawRecord.getOptionalStripped("hs_hosp_why_other")
         } else {
           None
         },
-      hsOtherMedicalInfo = rawRecord.getOptional("hs_other_med_info")
+      hsOtherMedicalInfo = rawRecord.getOptionalStripped("hs_other_med_info")
     )
   }
 
@@ -119,7 +119,7 @@ object HealthStatusTransformations {
       hsAlternativeCareTraditionalChineseMedicine = altCareMethods.map(_.contains("8")),
       hsAlternativeCareOther = otherAltCare,
       hsAlternativeCareOtherDescription = otherAltCare.flatMap {
-        if (_) rawRecord.getOptional("hs_other_health_care_other") else None
+        if (_) rawRecord.getOptionalStripped("hs_other_health_care_other") else None
       }
     )
   }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformations.scala
@@ -56,7 +56,7 @@ object MedsAndPreventativesTransformations {
           mpProfessionalGroomingShampoosUnknown = shampoos.map(_.contains("99")),
           mpProfessionalGroomingShampoosOther = shampoos.map(_.contains("98")),
           mpProfessionalGroomingShampoosOtherDescription = if (shampoos.exists(_.contains("98"))) {
-            rawRecord.getOptional("mp_gr_pro_shampoo_other")
+            rawRecord.getOptionalStripped("mp_gr_pro_shampoo_other")
           } else {
             None
           }
@@ -80,7 +80,7 @@ object MedsAndPreventativesTransformations {
           mpHomeGroomingShampoosUnknown = shampoos.map(_.contains("99")),
           mpHomeGroomingShampoosOther = shampoos.map(_.contains("98")),
           mpHomeGroomingShampoosOtherDescription = if (shampoos.exists(_.contains("98"))) {
-            rawRecord.getOptional("mp_gr_home_shampoo_other")
+            rawRecord.getOptionalStripped("mp_gr_home_shampoo_other")
           } else {
             None
           }
@@ -104,7 +104,7 @@ object MedsAndPreventativesTransformations {
           mpFleaAndTickTreatmentCollar = rawRecord.getOptionalBoolean("mp_flea_collar"),
           mpFleaAndTickTreatmentOther = otherTreatment,
           mpFleaAndTickTreatmentOtherDescription = otherTreatment.flatMap {
-            if (_) rawRecord.getOptional("mp_flea_other") else None
+            if (_) rawRecord.getOptionalStripped("mp_flea_other") else None
           }
         )
       } else {
@@ -126,7 +126,7 @@ object MedsAndPreventativesTransformations {
           mpHeartwormPreventativeInjectable = rawRecord.getOptionalBoolean("mp_hw_injectable"),
           mpHeartwormPreventativeOther = otherTreatment,
           mpHeartwormPreventativeOtherDescription = otherTreatment.flatMap {
-            if (_) rawRecord.getOptional("mp_hw_other") else None
+            if (_) rawRecord.getOptionalStripped("mp_hw_other") else None
           }
         )
       } else {
@@ -163,7 +163,7 @@ object MedsAndPreventativesTransformations {
       mpRecentNonPrescriptionMedsVitamin = rawRecord.getOptionalBoolean("mp_np_vitamin"),
       mpRecentNonPrescriptionMedsOther = otherNonPrescription,
       mpRecentNonPrescriptionMedsOtherDescription = otherNonPrescription.flatMap {
-        if (_) rawRecord.getOptional("mp_np_other") else None
+        if (_) rawRecord.getOptionalStripped("mp_np_other") else None
       }
     )
   }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/PhysicalActivityTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/PhysicalActivityTransformations.scala
@@ -91,7 +91,7 @@ object PhysicalActivityTransformations {
         if (hasModerateWeather) rawRecord.getOptionalBoolean("pa_w_astro") else None,
       paModerateWeatherOutdoorOtherSurface = moderateWeatherOtherSurface,
       paModerateWeatherOutdoorOtherSurfaceDescription =
-        if (moderateWeatherOtherSurface.getOrElse(false)) rawRecord.getOptional("pa_w_other")
+        if (moderateWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripped("pa_w_other")
         else None,
       paModerateWeatherSunExposureLevel = rawRecord.getOptionalNumber("pa_w_sun"),
       // hot weather
@@ -113,7 +113,7 @@ object PhysicalActivityTransformations {
         if (hasHotWeather) rawRecord.getOptionalBoolean("pa_h_astro") else None,
       paHotWeatherOutdoorOtherSurface = hotWeatherOtherSurface,
       paHotWeatherOutdoorOtherSurfaceDescription =
-        if (hotWeatherOtherSurface.getOrElse(false)) rawRecord.getOptional("pa_h_other")
+        if (hotWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripped("pa_h_other")
         else None,
       paHotWeatherSunExposureLevel = rawRecord.getOptionalNumber("pa_h_sun"),
       // cold weather
@@ -135,7 +135,7 @@ object PhysicalActivityTransformations {
         if (hasColdWeather) rawRecord.getOptionalBoolean("pa_c_astro") else None,
       paColdWeatherOutdoorOtherSurface = coldWeatherOtherSurface,
       paColdWeatherOutdoorOtherSurfaceDescription =
-        if (coldWeatherOtherSurface.getOrElse(false)) rawRecord.getOptional("pa_c_other")
+        if (coldWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripepd("pa_c_other")
         else None,
       paColdWeatherSunExposureLevel = rawRecord.getOptionalNumber("pa_c_sun")
     )
@@ -193,7 +193,7 @@ object PhysicalActivityTransformations {
         paOnLeashWalkReasonsTrainingObedience = walkReasons.map(_.contains("5")),
         paOnLeashWalkReasonsOther = otherWalkReason,
         paOnLeashWalkReasonsOtherDescription =
-          if (otherWalkReason.contains(true)) rawRecord.getOptional("pa_walk_leash_why_other")
+          if (otherWalkReason.contains(true)) rawRecord.getOptionalStripped("pa_walk_leash_why_other")
           else None
       )
     } else dogWithBasicLeashInfo
@@ -224,7 +224,7 @@ object PhysicalActivityTransformations {
         paOffLeashWalkReasonsTrainingObedience = walkReasons.map(_.contains("5")),
         paOffLeashWalkReasonsOther = otherWalkReason,
         paOffLeashWalkReasonsOtherDescription =
-          if (otherWalkReason.contains(true)) rawRecord.getOptional("pa_walk_unleash_why_other")
+          if (otherWalkReason.contains(true)) rawRecord.getOptionalStripped("pa_walk_unleash_why_other")
           else None,
         paOffLeashWalkInEnclosedArea = rawRecord.getOptionalBoolean("pa_walk_unleash_contain_yn"),
         paOffLeashWalkInOpenArea = rawRecord.getOptionalBoolean("pa_walk_unleash_open"),
@@ -255,7 +255,7 @@ object PhysicalActivityTransformations {
           paSwimLocationsOcean = swimLocations.map(_.contains("5")),
           paSwimLocationsOther = otherSwimLocation,
           paSwimLocationsOtherDescription =
-            if (otherSwimLocation.contains(true)) rawRecord.getOptional("pa_swim_location_other")
+            if (otherSwimLocation.contains(true)) rawRecord.getOptionalStripped("pa_swim_location_other")
             else None
         )
       } else {

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/PhysicalActivityTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/PhysicalActivityTransformations.scala
@@ -91,7 +91,8 @@ object PhysicalActivityTransformations {
         if (hasModerateWeather) rawRecord.getOptionalBoolean("pa_w_astro") else None,
       paModerateWeatherOutdoorOtherSurface = moderateWeatherOtherSurface,
       paModerateWeatherOutdoorOtherSurfaceDescription =
-        if (moderateWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripped("pa_w_other")
+        if (moderateWeatherOtherSurface.getOrElse(false))
+          rawRecord.getOptionalStripped("pa_w_other")
         else None,
       paModerateWeatherSunExposureLevel = rawRecord.getOptionalNumber("pa_w_sun"),
       // hot weather
@@ -135,7 +136,7 @@ object PhysicalActivityTransformations {
         if (hasColdWeather) rawRecord.getOptionalBoolean("pa_c_astro") else None,
       paColdWeatherOutdoorOtherSurface = coldWeatherOtherSurface,
       paColdWeatherOutdoorOtherSurfaceDescription =
-        if (coldWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripepd("pa_c_other")
+        if (coldWeatherOtherSurface.getOrElse(false)) rawRecord.getOptionalStripped("pa_c_other")
         else None,
       paColdWeatherSunExposureLevel = rawRecord.getOptionalNumber("pa_c_sun")
     )
@@ -193,7 +194,8 @@ object PhysicalActivityTransformations {
         paOnLeashWalkReasonsTrainingObedience = walkReasons.map(_.contains("5")),
         paOnLeashWalkReasonsOther = otherWalkReason,
         paOnLeashWalkReasonsOtherDescription =
-          if (otherWalkReason.contains(true)) rawRecord.getOptionalStripped("pa_walk_leash_why_other")
+          if (otherWalkReason.contains(true))
+            rawRecord.getOptionalStripped("pa_walk_leash_why_other")
           else None
       )
     } else dogWithBasicLeashInfo
@@ -224,7 +226,8 @@ object PhysicalActivityTransformations {
         paOffLeashWalkReasonsTrainingObedience = walkReasons.map(_.contains("5")),
         paOffLeashWalkReasonsOther = otherWalkReason,
         paOffLeashWalkReasonsOtherDescription =
-          if (otherWalkReason.contains(true)) rawRecord.getOptionalStripped("pa_walk_unleash_why_other")
+          if (otherWalkReason.contains(true))
+            rawRecord.getOptionalStripped("pa_walk_unleash_why_other")
           else None,
         paOffLeashWalkInEnclosedArea = rawRecord.getOptionalBoolean("pa_walk_unleash_contain_yn"),
         paOffLeashWalkInOpenArea = rawRecord.getOptionalBoolean("pa_walk_unleash_open"),
@@ -255,7 +258,8 @@ object PhysicalActivityTransformations {
           paSwimLocationsOcean = swimLocations.map(_.contains("5")),
           paSwimLocationsOther = otherSwimLocation,
           paSwimLocationsOtherDescription =
-            if (otherSwimLocation.contains(true)) rawRecord.getOptionalStripped("pa_swim_location_other")
+            if (otherSwimLocation.contains(true))
+              rawRecord.getOptionalStripped("pa_swim_location_other")
             else None
         )
       } else {

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -82,7 +82,7 @@ object ResidentialEnvironmentTransformations {
     dog.copy(
       deHomeAreaType = rawRecord.getOptionalNumber("de_type_area"),
       deHomeType = rawRecord.getOptionalNumber("de_type_home"),
-      deHomeTypeOtherDescription = rawRecord.getOptional("he_type_home_other"),
+      deHomeTypeOtherDescription = rawRecord.getOptionalStripped("de_type_home_other"),
       deHomeConstructionDecade = rawRecord.getOptionalNumber("de_home_age"),
       deHomeYearsLivedIn = rawRecord.getOptionalNumber("de_home_lived_years"),
       deHomeSquareFootage = rawRecord.getOptionalNumber("de_home_area", truncateDecimals = true)
@@ -110,18 +110,18 @@ object ResidentialEnvironmentTransformations {
     dog.copy(
       dePrimaryHeatFuel = primaryHeat,
       dePrimaryHeatFuelOtherDescription =
-        if (primaryHeat.contains(98L)) rawRecord.getOptional("de_primary_heat_other") else None,
+        if (primaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_primary_heat_other") else None,
       deSecondaryHeatFuelUsed = secondaryHeatUsed,
       deSecondaryHeatFuel = secondaryHeat,
       deSecondaryHeatFuelOtherDescription =
-        if (secondaryHeat.contains(98L)) rawRecord.getOptional("de_secondary_heat_other") else None,
+        if (secondaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_secondary_heat_other") else None,
       dePrimaryStoveFuel = primaryStove,
       dePrimaryStoveFuelOtherDescription =
-        if (primaryStove.contains(98L)) rawRecord.getOptional("de_primary_stove_other") else None,
+        if (primaryStove.contains(98L)) rawRecord.getOptionalStripped("de_primary_stove_other") else None,
       deSecondaryStoveFuelUsed = secondaryStoveUsed,
       deSecondaryStoveFuel = secondaryStove,
       deSecondaryStoveFuelOtherDescription = if (secondaryStove.contains(98L)) {
-        rawRecord.getOptional("de_secondary_stove_other")
+        rawRecord.getOptionalStripped("de_secondary_stove_other")
       } else {
         None
       }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -110,14 +110,17 @@ object ResidentialEnvironmentTransformations {
     dog.copy(
       dePrimaryHeatFuel = primaryHeat,
       dePrimaryHeatFuelOtherDescription =
-        if (primaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_primary_heat_other") else None,
+        if (primaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_primary_heat_other")
+        else None,
       deSecondaryHeatFuelUsed = secondaryHeatUsed,
       deSecondaryHeatFuel = secondaryHeat,
       deSecondaryHeatFuelOtherDescription =
-        if (secondaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_secondary_heat_other") else None,
+        if (secondaryHeat.contains(98L)) rawRecord.getOptionalStripped("de_secondary_heat_other")
+        else None,
       dePrimaryStoveFuel = primaryStove,
       dePrimaryStoveFuelOtherDescription =
-        if (primaryStove.contains(98L)) rawRecord.getOptionalStripped("de_primary_stove_other") else None,
+        if (primaryStove.contains(98L)) rawRecord.getOptionalStripped("de_primary_stove_other")
+        else None,
       deSecondaryStoveFuelUsed = secondaryStoveUsed,
       deSecondaryStoveFuel = secondaryStove,
       deSecondaryStoveFuelOtherDescription = if (secondaryStove.contains(98L)) {

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
@@ -48,7 +48,7 @@ object RoutineEnvironmentTransformations {
         deDogparkTravelOther = dogparkTravelOther,
         //ONLY if: de_dogpark_get_to(98) = '1'
         deDogparkTravelOtherDescription = if (dogparkTravelOther.contains(true)) {
-          rawRecord.getOptional("de_dogpark_get_to_other")
+          rawRecord.getOptionalStripped("de_dogpark_get_to_other")
         } else {
           None
         },
@@ -82,7 +82,7 @@ object RoutineEnvironmentTransformations {
         deRecreationalSpacesTravelOther = dogRecSpacesTravelOther,
         //ONLY if: de_spaces_get_to(98) = '1'
         deRecreationalSpacesTravelOtherDescription = if (dogRecSpacesTravelOther.contains(true)) {
-          rawRecord.getOptional("de_spaces_get_to_other")
+          rawRecord.getOptionalStripped("de_spaces_get_to_other")
         } else {
           None
         },
@@ -113,7 +113,7 @@ object RoutineEnvironmentTransformations {
         deWorkTravelOther = dogWorkTravelOther,
         // ONLY if: de_dog_to_work_how(98) = '1'
         deWorkTravelOtherDescription = if (dogWorkTravelOther.contains(true)) {
-          rawRecord.getOptional("de_dog_to_work_how_other")
+          rawRecord.getOptionalStripped("de_dog_to_work_how_other")
         } else {
           None
         },
@@ -144,7 +144,7 @@ object RoutineEnvironmentTransformations {
         deSitterOrDaycareTravelOther = dogSitterTravelOther,
         // ONLY if: de_sitter_how(98) = '1'
         deSitterOrDaycareTravelOtherDescription = if (dogSitterTravelOther.contains(true)) {
-          rawRecord.getOptional("de_sitter_how_other")
+          rawRecord.getOptionalStripped("de_sitter_how_other")
         } else {
           None
         },
@@ -190,7 +190,7 @@ object RoutineEnvironmentTransformations {
         deEatsFecesOther = eatsFecesOther,
         // ONLY if: de_eat_feces_type(98) = '1'
         deEatsFecesOtherDescription = if (eatsFecesOther.contains(true)) {
-          rawRecord.getOptional("de_eat_feces_type_other")
+          rawRecord.getOptionalStripped("de_eat_feces_type_other")
         } else {
           None
         },
@@ -230,7 +230,7 @@ object RoutineEnvironmentTransformations {
         deRoutineToysIncludeOther = otherToys,
         // ONLY if: de_toy_other_yn = '1'
         deRoutineToysOtherDescription = if (otherToys.contains(1L)) {
-          rawRecord.getOptional("de_toy_other")
+          rawRecord.getOptionalStripped("de_toy_other")
         } else {
           None
         },
@@ -262,7 +262,7 @@ object RoutineEnvironmentTransformations {
     // ONLY if: de_sleep_location_day = 98
     val daytimeSleepLocationOtherDescription =
       if (daytimeSleepLocation.contains(98L)) {
-        rawRecord.getOptional("de_sleep_loc_day_other")
+        rawRecord.getOptionalStripped("de_sleep_loc_day_other")
       } else {
         None
       }
@@ -270,7 +270,7 @@ object RoutineEnvironmentTransformations {
       deNighttimeSleepLocation = nighttimeSleepLocation,
       // ONLY if: de_sleep_location = '98'
       deNighttimeSleepLocationOtherDescription = if (nighttimeSleepLocation.contains(98L)) {
-        rawRecord.getOptional("de_sleep_location_other")
+        rawRecord.getOptionalStripped("de_sleep_location_other")
       } else {
         None
       },
@@ -290,7 +290,7 @@ object RoutineEnvironmentTransformations {
     val toxinsAmount = rawRecord.getOptionalNumber("de_ingest_bad_amt")
     //ONLY if: de_ingest_bad_amt = 1 OR de_ingest_bad_amt = 2
     if (toxinsAmount.exists(_ > 0)) {
-      val toxinsDescription = rawRecord.getOptional("de_ingest_bad").map(_.trim).filter(_.nonEmpty)
+      val toxinsDescription = rawRecord.getOptionalStripped("de_ingest_bad").map(_.trim).filter(_.nonEmpty)
       val toxinsIngested = rawRecord.get("de_ingest_bad_what")
       val recentToxinsOrHazardsIngestedOther = toxinsIngested.map(_.contains("98"))
       dog.copy(
@@ -309,7 +309,7 @@ object RoutineEnvironmentTransformations {
           // ONLY if: de_ingest_bad_what(98) = 1
           recentToxinsOrHazardsIngestedOther.fold(toxinsDescription) {
             if (_) {
-              rawRecord.getOptional("de_ingest_bad_what_other")
+              rawRecord.getOptionalStripped("de_ingest_bad_what_other")
             } else {
               toxinsDescription
             }
@@ -347,7 +347,7 @@ object RoutineEnvironmentTransformations {
         deOtherPresentAnimalsOther = otherPresentAnimalsOther,
         //ONLY if: de_other_other_yn = "1"
         deOtherPresentAnimalsOtherDescription = if (otherPresentAnimalsOther.contains(true)) {
-          rawRecord.getOptional("de_other_other")
+          rawRecord.getOptionalStripped("de_other_other")
         } else {
           None
         },

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
@@ -290,7 +290,8 @@ object RoutineEnvironmentTransformations {
     val toxinsAmount = rawRecord.getOptionalNumber("de_ingest_bad_amt")
     //ONLY if: de_ingest_bad_amt = 1 OR de_ingest_bad_amt = 2
     if (toxinsAmount.exists(_ > 0)) {
-      val toxinsDescription = rawRecord.getOptionalStripped("de_ingest_bad").map(_.trim).filter(_.nonEmpty)
+      val toxinsDescription =
+        rawRecord.getOptionalStripped("de_ingest_bad").map(_.trim).filter(_.nonEmpty)
       val toxinsIngested = rawRecord.get("de_ingest_bad_what")
       val recentToxinsOrHazardsIngestedOther = toxinsIngested.map(_.contains("98"))
       dog.copy(

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/RawRecordSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/RawRecordSpec.scala
@@ -17,4 +17,20 @@ class RawRecordSpec extends AnyFlatSpec with Matchers {
     result shouldBe defined
     result shouldBe Some(LocalDate.parse("2020-07-26"))
   }
+
+  it should "strip tabs and both styles of newline when using getOptionalStripped" in {
+    val fields =
+      Map(
+        "dd_steve_greatness_other" -> Array(
+          "Much has\tbeen written\nabout the\r\ngreatness\nof Steve[clipped remaining 4098 chars]"
+        )
+      )
+
+    val record = RawRecord(456L, fields)
+    val result: Option[String] = record.getOptionalStripped("dd_steve_greatness_other")
+    result shouldBe defined
+    result shouldBe Some(
+      "Much has been written about the greatness of Steve[clipped remaining 4098 chars]"
+    )
+  }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -71,7 +71,7 @@ class ResidentialEnvironmentTransformationsSpec
     val exampleDogFields = Map[String, Array[String]](
       "de_type_area" -> Array("2000"),
       "de_type_home" -> Array("2"),
-      "he_type_home_other" -> Array("something else"),
+      "de_type_home_other" -> Array("something else"),
       "de_home_age" -> Array("75"),
       "de_home_lived_years" -> Array("10"),
       "de_home_area" -> Array("1000")


### PR DESCRIPTION
## Why

If you give users the freedom to put whatever they want in a field, at least one of them will put in whitespace that breaks our parsing.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1441)

## This PR

* Expands `getOptionalStripped` to also convert tab characters to spaces
* Applies `getOptionalStripped` to every free-text field in the survey (mostly description fields for 'other' responses)