### PR TITLE
Qh dspdc 1445 inject puppy weight

### DIFF
--- a/hles/logs/errors.log
+++ b/hles/logs/errors.log
@@ -1,0 +1,9 @@
+{"errorType":"MissingOwnerIdError","message":"Record 1 has less than 1 value for field st_owner_id"}
+{"errorType":"TruncatedDecimalError","message":"Record 1 has an unexpected decimal value in field de_home_area, truncated to integer"}
+{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
+{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
+{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
+{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
+{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
+{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
+{"errorType":"TruncatedDecimalError","message":"Record 1 has an unexpected decimal value in field cv_medianincomee, truncated to integer"}

--- a/hles/logs/errors.log
+++ b/hles/logs/errors.log
@@ -1,9 +1,0 @@
-{"errorType":"MissingOwnerIdError","message":"Record 1 has less than 1 value for field st_owner_id"}
-{"errorType":"TruncatedDecimalError","message":"Record 1 has an unexpected decimal value in field de_home_area, truncated to integer"}
-{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
-{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
-{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
-{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
-{"errorType":"MissingOwnerIdError","message":"Record 11111 has less than 1 value for field st_owner_id"}
-{"errorType":"MissingOwnerIdError","message":"Record 33333 has less than 1 value for field st_owner_id"}
-{"errorType":"TruncatedDecimalError","message":"Record 1 has an unexpected decimal value in field cv_medianincomee, truncated to integer"}

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/EnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/EnvironmentTransformations.scala
@@ -14,10 +14,10 @@ object EnvironmentTransformations {
     val redcapEventName = rawRecord.getRequired("redcap_event_name").split("_")
 
     // set address sequence
-    val addSeq: String =
+    val addSeq: Long =
       redcapEventName(1) match {
-        case "arm"       => "1"
-        case "secondary" => "2"
+        case "arm"       => 1L
+        case "secondary" => 2L
       }
 
     // set address month
@@ -49,8 +49,8 @@ object EnvironmentTransformations {
         Some(
           Environment(
             dogId = dogId,
-            addressMonth = addressMonthStr,
-            addressYear = addYear,
+            addressMonth = addressMonthStr.toLong,
+            addressYear = addYear.toLong,
             environmentGeocoding = Some(GeocodingTransformations.mapGeocodingMetadata(rawRecord)),
             environmentCensus = Some(CensusTransformations.mapCensusVariables(rawRecord)),
             environmentPollutants = Some(PollutantTransformations.mapPollutantVariables(rawRecord)),

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
@@ -47,7 +47,7 @@ object DietTransformations {
       // "2" from gated question maps to "puppy weight gain" so we inject a 3 to keep the distinction
       dfWeightChangeLastYear = weightChange.flatMap {
         case 1L    => Some(0L)
-        case 0L    => rawRecord.getOptionalNumber("df_weight_change_how")
+        case 0L    => Some(rawRecord.getRequired("df_weight_change_how").toLong)
         case 2L    => Some(3L)
         case other => Some(other)
       }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
@@ -43,9 +43,12 @@ object DietTransformations {
       dfEverUnderweight = rawRecord.getOptionalNumber("df_underweight"),
       // Note: "df_overrweight" raw field name is misspelled in RedCap
       dfEverOverweight = rawRecord.getOptionalNumber("df_overrweight"),
+      // "1" from gated question maps to "yes, weight stayed the same" so we inject 0
+      // "2" from gated question maps to "puppy weight gain" so we inject a 3 to keep the distinction
       dfWeightChangeLastYear = weightChange.flatMap {
         case 1L    => Some(0L)
         case 0L    => rawRecord.getOptionalNumber("df_weight_change_how")
+        case 2L    => Some(3L)
         case other => Some(other)
       }
     )

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/EnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/EnvironmentTransformationsSpec.scala
@@ -22,9 +22,9 @@ class EnvironmentTransformationsSpec extends AnyFlatSpec with Matchers with Opti
     mapped shouldBe Some(
       Environment(
         dogId = 1L,
-        address1Or2 = "2",
-        addressMonth = "9",
-        addressYear = "2020",
+        address1Or2 = 2L,
+        addressMonth = 9L,
+        addressYear = 2020L,
         environmentGeocoding = Some(EnvironmentGeocoding.init()),
         environmentCensus = Some(EnvironmentCensus.init()),
         environmentPollutants = Some(EnvironmentPollutants.init()),
@@ -48,9 +48,9 @@ class EnvironmentTransformationsSpec extends AnyFlatSpec with Matchers with Opti
     mapped shouldBe Some(
       Environment(
         dogId = 1L,
-        address1Or2 = "1",
-        addressMonth = "12",
-        addressYear = "2019",
+        address1Or2 = 1L,
+        addressMonth = 12L,
+        addressYear = 2019L,
         environmentGeocoding = Some(EnvironmentGeocoding.init()),
         environmentCensus = Some(EnvironmentCensus.init()),
         environmentPollutants = Some(EnvironmentPollutants.init()),

--- a/schema/src/main/jade-tables/environment.table.json
+++ b/schema/src/main/jade-tables/environment.table.json
@@ -14,17 +14,17 @@
     },
     {
       "name": "address_1_or_2",
-      "datatype": "string",
+      "datatype": "integer",
       "type": "primary_key"
     },
     {
       "name": "address_month",
-      "datatype": "string",
+      "datatype": "integer",
       "type": "primary_key"
     },
     {
       "name": "address_year",
-      "datatype": "string",
+      "datatype": "integer",
       "type": "primary_key"
     }
   ],


### PR DESCRIPTION
## Why
DAP has requested that we inject a "3" for records with a value of "2" under df_weight_change rather than passing that value through.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1445)

## This PR

Added a new case for when a value of 2 is passed into the gated question, mapping it to a 3 for the follow up response.
Also caught a minor bugfix - environment table fields where redcap_event_name was parsed into address1Or2, addressMonth, and addressYear should be integers in the Terra table. (This won't matter until we are in production and not using the firecloud uploads)