### PR TITLE
Add back dePastResidenceZipCount

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -38,11 +38,14 @@ object ResidentialEnvironmentTransformations {
     rawRecord
       .getOptionalNumber("de_home_nbr")
       .fold(dog.copy(deLifetimeResidenceCount = currentResidenceCount)) { pastResidenceCount =>
+        val pastZipCount =
+          if (pastResidenceCount > 0) rawRecord.getRequired("de_zip_nbr").toLong else 0L
         val pastCountryCount =
           if (pastResidenceCount > 0) rawRecord.getRequired("de_country_nbr").toLong else 0L
 
         dog.copy(
           deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
+          dePastResidenceZipCount = Some(pastZipCount),
           dePastResidenceCountryCount = Some(pastCountryCount),
           dePastResidenceCountry1 = if (pastCountryCount > 1) {
             rawRecord.getOptional("de_country_01")

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -14,6 +14,7 @@ class ResidentialEnvironmentTransformationsSpec
   it should "map all past-residence-related fields" in {
     val exampleDogFields = Map[String, Array[String]](
       "de_home_nbr" -> Array("10"),
+      "de_zip_nbr" -> Array("10"),
       "oc_address2_yn" -> Array("1"),
       "de_country_nbr" -> Array("10"),
       "de_country_01_only" -> Array("this should be ignored too"),
@@ -34,6 +35,7 @@ class ResidentialEnvironmentTransformationsSpec
       )
 
     output.deLifetimeResidenceCount.value shouldBe 12
+    output.dePastResidenceZipCount.value shouldBe 10
     output.dePastResidenceCountryCount.value shouldBe 10
     output.dePastResidenceCountry1.value shouldBe "country1"
     output.dePastResidenceCountry2.value shouldBe "country2"
@@ -50,6 +52,7 @@ class ResidentialEnvironmentTransformationsSpec
   it should "map past-residence-related fields where there is a single past and current home" in {
     val exampleDogFields = Map[String, Array[String]](
       "de_home_nbr" -> Array("1"),
+      "de_zip_nbr" -> Array("1"),
       "oc_address2_yn" -> Array("0"),
       "de_country_nbr" -> Array("1"),
       "de_country_01_only" -> Array("USA!"),
@@ -62,6 +65,7 @@ class ResidentialEnvironmentTransformationsSpec
       )
 
     output.deLifetimeResidenceCount.value shouldBe 2
+    output.dePastResidenceZipCount.value shouldBe 1
     output.dePastResidenceCountryCount.value shouldBe 1
     output.dePastResidenceCountry1.value shouldBe "USA!"
     output.dePastResidenceCountry2 shouldBe None

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -6,6 +6,10 @@
       "datatype": "integer"
     },
     {
+      "name": "de_past_residence_zip_count",
+      "datatype": "integer"
+    },
+    {
       "name": "de_past_residence_country_count",
       "datatype": "integer"
     },


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1459)
The `de_past_residence_zip_count` should be passed through to Terra.

## This PR
* Adds back the relevant field to the schema and adds it back to the transformation code

