### PR TITLE
Add a new field hles_dog field "hs_alternative_care_none"

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
@@ -109,6 +109,7 @@ object HealthStatusTransformations {
     val otherAltCare = altCareMethods.map(_.contains("98"))
 
     dog.copy(
+      hsAlternativeCareNone = altCareMethods.map(_.contains("0")),
       hsAlternativeCareAcupuncture = altCareMethods.map(_.contains("1")),
       hsAlternativeCareHerbalMedicine = altCareMethods.map(_.contains("2")),
       hsAlternativeCareHomeopathy = altCareMethods.map(_.contains("3")),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
@@ -122,6 +122,7 @@ class HealthStatusTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       HlesDogHealthSummary.init()
     )
 
+    out.hsAlternativeCareNone.value shouldBe false
     out.hsAlternativeCareAcupuncture.value shouldBe true
     out.hsAlternativeCareHerbalMedicine.value shouldBe false
     out.hsAlternativeCareHomeopathy.value shouldBe true

--- a/schema/src/main/jade-fragments/hles_dog_health_summary.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_health_summary.fragment.json
@@ -134,6 +134,10 @@
       "datatype": "integer"
     },
     {
+      "name": "hs_alternative_care_none",
+      "datatype": "boolean"
+    },
+    {
       "name": "hs_alternative_care_acupuncture",
       "datatype": "boolean"
     },


### PR DESCRIPTION
## Why
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1464)
The hles_dog table is missing data - we need to include a column corresponding to [hs_other_health_care__99] = “None of the above”

## This PR
- Added a new field "hs_alternative_care_none" to the hles_dog_health_summary fragment
- Extended the HealthStatusTransformations to map this new column from an additional RedCap option
- Updated unit tests to check mapping of this new field