### PR TITLE
Added new columns for "none" options on shampoo types used

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformations.scala
@@ -53,6 +53,7 @@ object MedsAndPreventativesTransformations {
           mpProfessionalGroomingShampoosRegular = shampoos.map(_.contains("1")),
           mpProfessionalGroomingShampoosFleaOrTickControl = shampoos.map(_.contains("2")),
           mpProfessionalGroomingShampoosMedicated = shampoos.map(_.contains("3")),
+          mpProfessionalGroomingShampoosNone = shampoos.map(_.contains("4")),
           mpProfessionalGroomingShampoosUnknown = shampoos.map(_.contains("99")),
           mpProfessionalGroomingShampoosOther = shampoos.map(_.contains("98")),
           mpProfessionalGroomingShampoosOtherDescription = if (shampoos.exists(_.contains("98"))) {
@@ -77,6 +78,7 @@ object MedsAndPreventativesTransformations {
           mpHomeGroomingShampoosRegular = shampoos.map(_.contains("1")),
           mpHomeGroomingShampoosFleaOrTickControl = shampoos.map(_.contains("2")),
           mpHomeGroomingShampoosMedicated = shampoos.map(_.contains("3")),
+          mpHomeGroomingShampoosNone = shampoos.map(_.contains("4")),
           mpHomeGroomingShampoosUnknown = shampoos.map(_.contains("99")),
           mpHomeGroomingShampoosOther = shampoos.map(_.contains("98")),
           mpHomeGroomingShampoosOtherDescription = if (shampoos.exists(_.contains("98"))) {

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/MedsAndPreventativesTransformationsSpec.scala
@@ -52,6 +52,7 @@ class MedsAndPreventativesTransformationsSpec extends AnyFlatSpec with Matchers 
     out.mpProfessionalGroomingShampoosRegular.value shouldBe true
     out.mpProfessionalGroomingShampoosFleaOrTickControl.value shouldBe false
     out.mpProfessionalGroomingShampoosMedicated.value shouldBe true
+    out.mpProfessionalGroomingShampoosNone.value shouldBe false
     out.mpProfessionalGroomingShampoosUnknown.value shouldBe false
     out.mpProfessionalGroomingShampoosOther.value shouldBe true
     out.mpProfessionalGroomingShampoosOtherDescription.value shouldBe "Magic shampoo"
@@ -60,7 +61,7 @@ class MedsAndPreventativesTransformationsSpec extends AnyFlatSpec with Matchers 
   it should "map home grooming fields" in {
     val example = Map(
       "mp_gr_home" -> Array("1"),
-      "mp_gr_home_shampoo" -> Array("2", "99", "98"),
+      "mp_gr_home_shampoo" -> Array("2", "4", "99", "98"),
       "mp_gr_home_shampoo_other" -> Array("Secret sauce")
     )
 
@@ -73,6 +74,7 @@ class MedsAndPreventativesTransformationsSpec extends AnyFlatSpec with Matchers 
     out.mpHomeGroomingShampoosRegular.value shouldBe false
     out.mpHomeGroomingShampoosFleaOrTickControl.value shouldBe true
     out.mpHomeGroomingShampoosMedicated.value shouldBe false
+    out.mpHomeGroomingShampoosNone.value shouldBe true
     out.mpHomeGroomingShampoosUnknown.value shouldBe true
     out.mpHomeGroomingShampoosOther.value shouldBe true
     out.mpHomeGroomingShampoosOtherDescription.value shouldBe "Secret sauce"

--- a/schema/src/main/jade-fragments/hles_dog_meds_preventatives.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_meds_preventatives.fragment.json
@@ -62,6 +62,10 @@
       "datatype": "boolean"
     },
     {
+      "name": "mp_professional_grooming_shampoos_none",
+      "datatype": "boolean"
+    },
+    {
       "name": "mp_professional_grooming_shampoos_unknown",
       "datatype": "boolean"
     },
@@ -91,6 +95,10 @@
     },
     {
       "name": "mp_home_grooming_shampoos_medicated",
+      "datatype": "boolean"
+    },
+    {
+      "name": "mp_home_grooming_shampoos_none",
       "datatype": "boolean"
     },
     {


### PR DESCRIPTION
## Why
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1463)
The following options are not available anywhere in hles_dog:
mp_gr_pro_shampoo___4 | None
mp_gr_home_shampoo___4 | None
Need to add two new columns + logic to map those columns.

## This PR
Added two new columns for the "none" option for shampoo choices: mp_professional_grooming_shampoos_none, mp_home_grooming_shampoos_none
Added transformation logic to map those RedCap options to the new variables.
Updated unit test cases
