### PR TITLE
Removing duplicated address fields between two tables

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/OwnerTransformations.scala
@@ -70,6 +70,9 @@ object OwnerTransformations {
               } else {
                 None
               },
+            ocPrimaryResidenceTimePercentage = secondaryAddress.flatMap {
+              if (_) rawRecord.getOptionalNumber("oc_address1_pct") else None
+            },
             ocSecondaryResidence = secondaryAddress,
             ocSecondaryResidenceState = secondaryAddress.flatMap {
               if (_) rawRecord.getOptional("oc_address2_state") else None
@@ -80,7 +83,10 @@ object OwnerTransformations {
                 rawRecord.getOptionalStripped("oc_address2_own_other")
               } else {
                 None
-              }
+              },
+            ocSecondaryResidenceTimePercentage = secondaryAddress.flatMap {
+              if (_) rawRecord.getOptionalNumber("oc_2nd_address_pct") else None
+            }
           )
         )
     }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/OwnerTransformationsSpec.scala
@@ -24,10 +24,12 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     "oc_address1_division" -> Array("Division 3: East North Central"),
     "oc_address1_own" -> Array("98"),
     "oc_address1_own_other" -> Array("some text"),
+    "oc_address1_pct" -> Array("1"),
     "oc_address2_yn" -> Array("1"),
     "oc_address2_state" -> Array("MA"),
     "oc_address2_own" -> Array("98"),
-    "oc_address2_own_other" -> Array("some text")
+    "oc_address2_own_other" -> Array("some text"),
+    "oc_2nd_address_pct" -> Array("2")
   )
 
   it should "correctly map owner values when all values are defined" in {
@@ -62,10 +64,12 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
           ocPrimaryResidenceCensusDivision = Some(3),
           ocPrimaryResidenceOwnership = Some(98),
           ocPrimaryResidenceOwnershipOtherDescription = Some("some text"),
+          ocPrimaryResidenceTimePercentage = Some(1),
           ocSecondaryResidence = Some(true),
           ocSecondaryResidenceState = Some("MA"),
           ocSecondaryResidenceOwnership = Some(98),
-          ocSecondaryResidenceOwnershipOtherDescription = Some("some text")
+          ocSecondaryResidenceOwnershipOtherDescription = Some("some text"),
+          ocSecondaryResidenceTimePercentage = Some(2)
         )
       )
     }
@@ -80,6 +84,7 @@ class OwnerTransformationsSpec extends AnyFlatSpec with Matchers {
     output match {
       case None => FailedStatus
       case Some(owner) =>
+        owner.ocPrimaryResidenceTimePercentage shouldBe None
         owner.ocSecondaryResidenceState shouldBe None
         owner.ocSecondaryResidenceOwnership shouldBe None
         owner.ocSecondaryResidenceOwnershipOtherDescription shouldBe None

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DogResidenceTransformationsSpec.scala
@@ -8,25 +8,6 @@ import org.scalatest.matchers.should.Matchers
 class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
   behavior of "DogResidenceTransformations"
 
-  it should "map residence-related fields with one address" in {
-    val oneAddress = Map[String, Array[String]](
-      "oc_address2_yn" -> Array("0"),
-      "dd_2nd_residence_yn" -> Array("0"),
-      "oc_address1_state" -> Array("MA"),
-      "oc_address1_own" -> Array("98"),
-      "oc_address1_own_other" -> Array("Squatter's rights"),
-      "oc_address1_pct" -> Array("2")
-    )
-
-    val oneAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, oneAddress))
-    oneAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
-    oneAddrOut.ocPrimaryResidenceOwnership.value shouldBe 98L
-    oneAddrOut.ocPrimaryResidenceOwnershipOtherDescription.value shouldBe "Squatter's rights"
-    // Not a typo: Time percentage not carried forward if only 1 address.
-    oneAddrOut.ocPrimaryResidenceTimePercentage shouldBe None
-    oneAddrOut.ocSecondaryResidence.value shouldBe false
-  }
-
   it should "map residence-related demographics fields" in {
     val manyAddresses = Map[String, Array[String]](
       "oc_address2_yn" -> Array("1"),
@@ -49,15 +30,6 @@ class DogResidenceTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     )
 
     val manyAddrOut = DogResidenceTransformations.mapDogResidences(RawRecord(1, manyAddresses))
-    manyAddrOut.ocPrimaryResidenceState.value shouldBe "MA"
-    manyAddrOut.ocPrimaryResidenceCensusDivision.value shouldBe 33L
-    manyAddrOut.ocPrimaryResidenceOwnership.value shouldBe 1L
-    manyAddrOut.ocPrimaryResidenceTimePercentage.value shouldBe 1L
-    manyAddrOut.ocSecondaryResidence.value shouldBe true
-    manyAddrOut.ocSecondaryResidenceState.value shouldBe "MA"
-    manyAddrOut.ocSecondaryResidenceOwnership.value shouldBe 98L
-    manyAddrOut.ocSecondaryResidenceOwnershipOtherDescription.value shouldBe "Foo"
-    manyAddrOut.ocSecondaryResidenceTimePercentage.value shouldBe 3L
     manyAddrOut.ddAlternateRecentResidence1State.value shouldBe "NH"
     manyAddrOut.ddAlternateRecentResidence1Weeks.value shouldBe 1L
     manyAddrOut.ddAlternateRecentResidence2State.value shouldBe "VT"

--- a/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residences.fragment.json
@@ -2,46 +2,6 @@
   "name": "hles_dog_residences",
   "columns": [
     {
-      "name": "oc_primary_residence_state",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_primary_residence_census_division",
-      "datatype": "integer"
-    },
-    {
-      "name": "oc_primary_residence_ownership",
-      "datatype": "integer"
-    },
-    {
-      "name": "oc_primary_residence_ownership_other_description",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_primary_residence_time_percentage",
-      "datatype": "integer"
-    },
-    {
-      "name": "oc_secondary_residence",
-      "datatype": "boolean"
-    },
-    {
-      "name": "oc_secondary_residence_state",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_secondary_residence_ownership",
-      "datatype": "integer"
-    },
-    {
-      "name": "oc_secondary_residence_ownership_other_description",
-      "datatype": "string"
-    },
-    {
-      "name": "oc_secondary_residence_time_percentage",
-      "datatype": "integer"
-    },
-    {
       "name": "dd_alternate_recent_residence_count",
       "datatype": "integer"
     },

--- a/schema/src/main/jade-tables/hles_owner.table.json
+++ b/schema/src/main/jade-tables/hles_owner.table.json
@@ -91,6 +91,10 @@
       "datatype": "string"
     },
     {
+      "name": "oc_primary_residence_time_percentage",
+      "datatype": "integer"
+    },
+    {
       "name": "oc_secondary_residence",
       "datatype": "boolean"
     },
@@ -105,6 +109,10 @@
     {
       "name": "oc_secondary_residence_ownership_other_description",
       "datatype": "string"
+    },
+    {
+      "name": "oc_secondary_residence_time_percentage",
+      "datatype": "integer"
     }
   ]
 }


### PR DESCRIPTION
## Why
At some point there was a Data Model/Schema design decision that was made that resulted in us duplicating a set of 10 address columns across two of our tables: hles_dog and hles_owner. The DAP folks have reached out and asked if we can only include these columns in hles_owner as it is causing issues for their workflows to have them in both.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1470)

## This PR
Removed the 10 owner address columns from the hles_dog_residences json fragment, transformation code, and associated unit tests.
Added the two missing percentage fields to the owner table json, transformation code, and unit tests
