### PR TITLE
Update deprecated address fields for past dog residences

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -24,6 +24,19 @@ object ResidentialEnvironmentTransformations {
   }
 
   /**
+    * Parse both country fields for a RedCap record,
+    * de_country_[n] is the deprecated user entry free text field
+    * de_country_[n]_dd is the updated drop down option list
+    */
+  def parseCountry(
+    rawRecord: RawRecord,
+    countryField: String,
+    countryFieldDropdown: String
+  ): Option[String] = {
+    rawRecord.getOptional(countryField).orElse(rawRecord.getOptional(countryFieldDropdown))
+  }
+
+  /**
     * Parse all past-residence-related fields out of a raw RedCap record,
     * injecting them into a partially-modeled dog record.
     */
@@ -31,10 +44,8 @@ object ResidentialEnvironmentTransformations {
     rawRecord: RawRecord,
     dog: HlesDogResidentialEnvironment
   ): HlesDogResidentialEnvironment = {
-    val currentResidenceCount = rawRecord.getOptionalBoolean("oc_address2_yn").map {
-      case true  => 2L
-      case false => 1L
-    }
+    val currentResidenceCount = rawRecord.getOptionalBoolean("oc_address2_yn").map(if (_) 2L else 1L)
+
     rawRecord
       .getOptionalNumber("de_home_nbr")
       .fold(dog.copy(deLifetimeResidenceCount = currentResidenceCount)) { pastResidenceCount =>
@@ -48,28 +59,37 @@ object ResidentialEnvironmentTransformations {
           dePastResidenceZipCount = Some(pastZipCount),
           dePastResidenceCountryCount = Some(pastCountryCount),
           dePastResidenceCountry1 = if (pastCountryCount > 1) {
-            rawRecord.getOptional("de_country_01")
+            parseCountry(rawRecord, "de_country_01", "de_country_01_dd")
           } else {
-            rawRecord.getOptional("de_country_01_only")
+            parseCountry(rawRecord, "de_country_01_only", "de_country_01_only_dd")
           },
           dePastResidenceCountry2 =
-            if (pastCountryCount > 1) rawRecord.getOptional("de_country_02") else None,
+            if (pastCountryCount > 1) parseCountry(rawRecord, "de_country_02", "de_country_02_dd")
+            else None,
           dePastResidenceCountry3 =
-            if (pastCountryCount > 2) rawRecord.getOptional("de_country_03") else None,
+            if (pastCountryCount > 2) parseCountry(rawRecord, "de_country_03", "de_country_03_dd")
+            else None,
           dePastResidenceCountry4 =
-            if (pastCountryCount > 3) rawRecord.getOptional("de_country_04") else None,
+            if (pastCountryCount > 3) parseCountry(rawRecord, "de_country_04", "de_country_04_dd")
+            else None,
           dePastResidenceCountry5 =
-            if (pastCountryCount > 4) rawRecord.getOptional("de_country_05") else None,
+            if (pastCountryCount > 4) parseCountry(rawRecord, "de_country_05", "de_country_05_dd")
+            else None,
           dePastResidenceCountry6 =
-            if (pastCountryCount > 5) rawRecord.getOptional("de_country_06") else None,
+            if (pastCountryCount > 5) parseCountry(rawRecord, "de_country_06", "de_country_06_dd")
+            else None,
           dePastResidenceCountry7 =
-            if (pastCountryCount > 6) rawRecord.getOptional("de_country_07") else None,
+            if (pastCountryCount > 6) parseCountry(rawRecord, "de_country_07", "de_country_07_dd")
+            else None,
           dePastResidenceCountry8 =
-            if (pastCountryCount > 7) rawRecord.getOptional("de_country_08") else None,
+            if (pastCountryCount > 7) parseCountry(rawRecord, "de_country_08", "de_country_08_dd")
+            else None,
           dePastResidenceCountry9 =
-            if (pastCountryCount > 8) rawRecord.getOptional("de_country_09") else None,
+            if (pastCountryCount > 8) parseCountry(rawRecord, "de_country_09", "de_country_09_dd")
+            else None,
           dePastResidenceCountry10 =
-            if (pastCountryCount > 9) rawRecord.getOptional("de_country_10") else None
+            if (pastCountryCount > 9) parseCountry(rawRecord, "de_country_10", "de_country_10_dd")
+            else None
         )
       }
   }

--- a/hles/transformation/src/test/resources/org/broadinstitute/monster/dap/blank_st_owner_id/records/two_blank_owner_ids_of_three_records.json
+++ b/hles/transformation/src/test/resources/org/broadinstitute/monster/dap/blank_st_owner_id/records/two_blank_owner_ids_of_three_records.json
@@ -1124,7 +1124,11 @@
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"pa_timer_3","value":"25.65"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"pa_timer","value":"3.073"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"environment_complete","value":"2"}
-{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_home_nbr","value":"0"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_home_nbr","value":"2"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_zip_nbr","value":"2"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_country_nbr","value":"2"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_country_01","value":"USA"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_country_02_dd","value":"US"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_timer_14","value":"8.158"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_type_area","value":"1"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"de_type_home","value":"1"}
@@ -1461,4 +1465,5 @@
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"st_dap_pack_count","value":"14496"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"st_dap_pack_date","value":"2020-10-16 16:45"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"st_vemr_possible","value":"1"}
+{"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"st_vemr_date_due","value":"2020-11-26"}
 {"record":"33333","redcap_event_name":"jan2020_arm_1","field_name":"st_vemr_date_due","value":"2020-11-26"}

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -19,15 +19,15 @@ class ResidentialEnvironmentTransformationsSpec
       "de_country_nbr" -> Array("10"),
       "de_country_01_only" -> Array("this should be ignored too"),
       "de_country_01" -> Array("country1"),
-      "de_country_02" -> Array("country2"),
-      "de_country_03" -> Array("country3"),
+      "de_country_02_dd" -> Array("country2"),
+      "de_country_03_dd" -> Array("country3"),
       "de_country_04" -> Array("country4"),
       "de_country_05" -> Array("country5"),
       "de_country_06" -> Array("country6"),
       "de_country_07" -> Array("country7"),
-      "de_country_08" -> Array("country8"),
+      "de_country_08_dd" -> Array("country8"),
       "de_country_09" -> Array("country9"),
-      "de_country_10" -> Array("country10")
+      "de_country_10_dd" -> Array("country10")
     )
     val output =
       ResidentialEnvironmentTransformations.mapResidentialEnvironment(
@@ -68,6 +68,28 @@ class ResidentialEnvironmentTransformationsSpec
     output.dePastResidenceZipCount.value shouldBe 1
     output.dePastResidenceCountryCount.value shouldBe 1
     output.dePastResidenceCountry1.value shouldBe "USA!"
+    output.dePastResidenceCountry2 shouldBe None
+  }
+
+  it should "map past-residence-related fields where there is a single past and current home (dropdown)" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_home_nbr" -> Array("1"),
+      "de_zip_nbr" -> Array("1"),
+      "oc_address2_yn" -> Array("0"),
+      "de_country_nbr" -> Array("1"),
+      "de_country_01_only_dd" -> Array("US"),
+      "de_country_01" -> Array("this should be ignored"),
+      "de_country_02" -> Array("IgnoredCountry")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deLifetimeResidenceCount.value shouldBe 2
+    output.dePastResidenceZipCount.value shouldBe 1
+    output.dePastResidenceCountryCount.value shouldBe 1
+    output.dePastResidenceCountry1.value shouldBe "US"
     output.dePastResidenceCountry2 shouldBe None
   }
 


### PR DESCRIPTION
## Why

Early in the study, the DAP folks were letting users enter their past residence countries with a free text field.
After they learned their lesson they implemented a drop down pick list. It appears we were never pulling the new dropdown fields so here is the logic to check both.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1457)

## This PR

- Added a new parseCountry method to check two separate fields - the deprecated free text field and then the drop down option.
- Added unit test and integration test cases.
