### PR TITLE
Fixed inconsistencies in activities parser

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -60,7 +60,7 @@ object DemographicsTransformations {
         val dogId = rawRecord.id
         val formYear = rawRecord.getOptional("dd_dog_current_year_calc") match {
           case Some(year) => year.toInt
-          case None       =>
+          case None =>
             // we're throwing these errors instead of logging them because we want to completely skip records missing this value. they get logged
             // by the logic up the chain that catches the error.
             throw MissingCalcFieldError(
@@ -72,7 +72,7 @@ object DemographicsTransformations {
 
         val formMonth = rawRecord.getOptional("dd_dog_current_month_calc") match {
           case Some(month) => month.toInt
-          case None        =>
+          case None =>
             // we're throwing these errors instead of logging them because we want to completely skip records missing this value. they get logged
             // by the logic up the chain that catches the error.
             throw MissingCalcFieldError(
@@ -223,7 +223,7 @@ object DemographicsTransformations {
     val country = usBorn match {
       case Some("1") => Some("US")
       case Some("0") => rawRecord.getOptional("dd_us_born_no")
-      case other     => other
+      case other => other
     }
     val source = rawRecord.getOptionalNumber("dd_acquire_source")
     val locationKnown = usBorn.contains("1") && rawRecord.getBoolean("dd_acquired_location_yn")
@@ -272,7 +272,7 @@ object DemographicsTransformations {
         */
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
-        case None => if(allActivities.contains[Long](ActivityValues(activity))){
+        case None => if (allActivities.contains[Long](ActivityValues(activity))) {
           Some(3L)
         } else {
           None
@@ -309,7 +309,7 @@ object DemographicsTransformations {
       ddActivitiesOtherDescription = otherLevel.flatMap {
         case 1L => rawRecord.getOptionalStripped("dd_1st_activity_other")
         case 2L => rawRecord.getOptionalStripped("dd_2nd_activity_other")
-        case _  => None
+        case _ => None
       },
       ddActivitiesServiceSeeingEye = serviceTypes.map(_.contains("1")),
       ddActivitiesServiceHearingOrSignal = serviceTypes.map(_.contains("2")),

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -270,7 +270,7 @@ object DemographicsTransformations {
       if (allActivities.contains[Long](ActivityValues(activity))) {
         rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(Some(3L))
       } else {
-        None
+        rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(None)
       }
 
     val serviceLevel = activityLevel("service")

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -266,12 +266,19 @@ object DemographicsTransformations {
   def mapActivities(rawRecord: RawRecord, dog: HlesDogDemographics): HlesDogDemographics = {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
-    def activityLevel(activity: String): Option[Long] =
-      if (allActivities.contains[Long](ActivityValues(activity))) {
-        rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(Some(3L))
-      } else {
-        rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(None)
+    def activityLevel(activity: String): Option[Long] = {
+      /**
+        * Gets activity level regardless of activities_m check
+        */
+      rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
+        case Some(value) => Some(value)
+        case None => if(allActivities.contains[Long](ActivityValues(activity))){
+          Some(3L)
+        } else {
+          None
+        }
       }
+    }
 
     val serviceLevel = activityLevel("service")
     val assistanceLevel = activityLevel("assistance")

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -60,7 +60,7 @@ object DemographicsTransformations {
         val dogId = rawRecord.id
         val formYear = rawRecord.getOptional("dd_dog_current_year_calc") match {
           case Some(year) => year.toInt
-          case None =>
+          case None       =>
             // we're throwing these errors instead of logging them because we want to completely skip records missing this value. they get logged
             // by the logic up the chain that catches the error.
             throw MissingCalcFieldError(
@@ -72,7 +72,7 @@ object DemographicsTransformations {
 
         val formMonth = rawRecord.getOptional("dd_dog_current_month_calc") match {
           case Some(month) => month.toInt
-          case None =>
+          case None        =>
             // we're throwing these errors instead of logging them because we want to completely skip records missing this value. they get logged
             // by the logic up the chain that catches the error.
             throw MissingCalcFieldError(
@@ -223,7 +223,7 @@ object DemographicsTransformations {
     val country = usBorn match {
       case Some("1") => Some("US")
       case Some("0") => rawRecord.getOptional("dd_us_born_no")
-      case other => other
+      case other     => other
     }
     val source = rawRecord.getOptionalNumber("dd_acquire_source")
     val locationKnown = usBorn.contains("1") && rawRecord.getBoolean("dd_acquired_location_yn")
@@ -272,11 +272,12 @@ object DemographicsTransformations {
         */
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
-        case None => if (allActivities.contains[Long](ActivityValues(activity))) {
-          Some(3L)
-        } else {
-          None
-        }
+        case None =>
+          if (allActivities.contains[Long](ActivityValues(activity))) {
+            Some(3L)
+          } else {
+            None
+          }
       }
     }
 
@@ -309,7 +310,7 @@ object DemographicsTransformations {
       ddActivitiesOtherDescription = otherLevel.flatMap {
         case 1L => rawRecord.getOptionalStripped("dd_1st_activity_other")
         case 2L => rawRecord.getOptionalStripped("dd_2nd_activity_other")
-        case _ => None
+        case _  => None
       },
       ddActivitiesServiceSeeingEye = serviceTypes.map(_.contains("1")),
       ddActivitiesServiceHearingOrSignal = serviceTypes.map(_.contains("2")),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -496,28 +496,12 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_service_other_1" -> Array("Activity!")
     )
 
-    val activitiesDog = Map[String, Array[String]](
-      "dd_activities" -> Array("3", "5", "7", "9", "11", "98"),
-      "dd_assistance_m" -> Array("2"),
-      "dd_other_m" -> Array("1"),
-      "dd_companion_m" -> Array("1"),
-      "dd_1st_activity_other" -> Array("Activity?"),
-      "dd_service_type_1" -> Array("2", "4", "6", "98"),
-      "dd_service_medical_other_1" -> Array("Medical!"),
-      "dd_service_other_1" -> Array("Activity!")
-    )
-
     val serviceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, serviceDog),
       HlesDogDemographics.init()
     )
     val assistanceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, assistanceDog),
-      HlesDogDemographics.init()
-    )
-
-    val activitiesOut = DemographicsTransformations.mapActivities(
-      RawRecord(1, activitiesDog),
       HlesDogDemographics.init()
     )
 
@@ -548,6 +532,24 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     assistanceOut.ddActivitiesServiceOther.value shouldBe true
     assistanceOut.ddActivitiesServiceOtherMedicalDescription.value shouldBe "Medical!"
     assistanceOut.ddActivitiesServiceOtherDescription.value shouldBe "Activity!"
+
+  }
+  it should "map activity-related fallback fields" in {
+    val activitiesDog = Map[String, Array[String]](
+      "dd_activities" -> Array("3", "5", "7", "9", "11", "98"),
+      "dd_assistance_m" -> Array("2"),
+      "dd_other_m" -> Array("1"),
+      "dd_companion_m" -> Array("1"),
+      "dd_1st_activity_other" -> Array("Activity?"),
+      "dd_service_type_1" -> Array("2", "4", "6", "98"),
+      "dd_service_medical_other_1" -> Array("Medical!"),
+      "dd_service_other_1" -> Array("Activity!")
+    )
+
+    val activitiesOut = DemographicsTransformations.mapActivities(
+      RawRecord(1, activitiesDog),
+      HlesDogDemographics.init()
+    )
 
     activitiesOut.ddActivitiesCompanionAnimal.value shouldBe 1L
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -496,12 +496,28 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_service_other_1" -> Array("Activity!")
     )
 
+    val activitiesDog = Map[String, Array[String]](
+      "dd_activities" -> Array("3", "5", "7", "9", "11", "98"),
+      "dd_assistance_m" -> Array("2"),
+      "dd_other_m" -> Array("1"),
+      "dd_companion_m" -> Array("1"),
+      "dd_1st_activity_other" -> Array("Activity?"),
+      "dd_service_type_1" -> Array("2", "4", "6", "98"),
+      "dd_service_medical_other_1" -> Array("Medical!"),
+      "dd_service_other_1" -> Array("Activity!")
+    )
+
     val serviceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, serviceDog),
       HlesDogDemographics.init()
     )
     val assistanceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, assistanceDog),
+      HlesDogDemographics.init()
+    )
+
+    val activitiesOut = DemographicsTransformations.mapActivities(
+      RawRecord(1, activitiesDog),
       HlesDogDemographics.init()
     )
 
@@ -532,5 +548,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     assistanceOut.ddActivitiesServiceOther.value shouldBe true
     assistanceOut.ddActivitiesServiceOtherMedicalDescription.value shouldBe "Medical!"
     assistanceOut.ddActivitiesServiceOtherDescription.value shouldBe "Activity!"
+
+    activitiesOut.ddActivitiesCompanionAnimal.value shouldBe 1L
   }
 }


### PR DESCRIPTION
## Why
People may not have selected dd_activities_2 but selected dd_activities_m as a secondary activity. We want to keep the data for activities_m.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1473)
(https://broadinstitute.atlassian.net/browse/DSPDC-1474)

## This PR
Keeps the activity_m value even if the activity value wasn't selected. Another test was added to test this case
