### PR TITLE
Allow specifying state when 'US-born' is set to 'unknown'

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -226,7 +226,9 @@ object DemographicsTransformations {
       case other     => other
     }
     val source = rawRecord.getOptionalNumber("dd_acquire_source")
-    val locationKnown = usBorn.contains("1") && rawRecord.getBoolean("dd_acquired_location_yn")
+    // a state can be selected if dd_us_born is answered with either yes (1) or unknown (99).
+    //  the only time they won't provide one is if they explicitly said the dog is not from the US.
+    val locationKnown = !(usBorn.contains("0")) && rawRecord.getBoolean("dd_acquired_location_yn")
 
     dog.copy(
       ddAcquiredYear = rawRecord.getOptionalNumber("dd_acquire_year"),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -473,7 +473,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     internationalOut.ddAcquiredSource.value shouldBe 5L
 
     unknownOut.ddAcquiredCountry.value shouldBe "99"
-    unknownOut.ddAcquiredState shouldBe "OH"
+    unknownOut.ddAcquiredState.value shouldBe "OH"
     unknownOut.ddAcquiredSource.value shouldBe 98L
     unknownOut.ddAcquiredSourceOtherDescription.value shouldBe "?????"
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -469,10 +469,11 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     usBornOut.ddAcquiredSource.value shouldBe 2L
 
     internationalOut.ddAcquiredCountry.value shouldBe "UK"
+    internationalOut.ddAcquiredState.value shouldBe None
     internationalOut.ddAcquiredSource.value shouldBe 5L
 
     unknownOut.ddAcquiredCountry.value shouldBe "99"
-    unknownOut.ddAcquiredState shouldBe None
+    unknownOut.ddAcquiredState shouldBe "OH"
     unknownOut.ddAcquiredSource.value shouldBe 98L
     unknownOut.ddAcquiredSourceOtherDescription.value shouldBe "?????"
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -469,7 +469,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     usBornOut.ddAcquiredSource.value shouldBe 2L
 
     internationalOut.ddAcquiredCountry.value shouldBe "UK"
-    internationalOut.ddAcquiredState.value shouldBe None
+    internationalOut.ddAcquiredState shouldBe None
     internationalOut.ddAcquiredSource.value shouldBe 5L
 
     unknownOut.ddAcquiredCountry.value shouldBe "99"


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1494)

We were throwing away the state where a dog was acquired if their US-born status was "unknown", but this info was still being provided in that case and shouldn't be discarded.

## This PR