### PR TITLE
Do not filter out 0s for these values

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DietTransformations.scala
@@ -160,32 +160,27 @@ object DietTransformations {
   def mapDailySupplements(rawRecord: RawRecord, dog: HlesDogDiet): HlesDogDiet = {
     val dailySupps = rawRecord.getRequiredBoolean("df_supplement_daily")
     if (dailySupps) {
-      val otherSupps = rawRecord.getOptionalNumber("df_s_other").filter(_ != 0L)
+      val otherSupps = rawRecord.getOptionalNumber("df_s_other")
 
       dog.copy(
         dfDailySupplements = Some(dailySupps),
-        dfDailySupplementsBoneMeal = rawRecord.getOptionalNumber("df_s_bone_meal").filter(_ != 0L),
-        dfDailySupplementsGlucosamine =
-          rawRecord.getOptionalNumber("df_s_glucosamine").filter(_ != 0L),
-        dfDailySupplementsChondroitin =
-          rawRecord.getOptionalNumber("df_s_chondroitin").filter(_ != 0L),
-        dfDailySupplementsOtherJoint =
-          rawRecord.getOptionalNumber("df_s_joint_other").filter(_ != 0L),
-        dfDailySupplementsOmega3 = rawRecord.getOptionalNumber("df_s_omega3").filter(_ != 0L),
-        dfDailySupplementsNonOilSkin = rawRecord.getOptionalNumber("df_s_skin").filter(_ != 0L),
-        dfDailySupplementsVitamins = rawRecord.getOptionalNumber("df_s_vitamin").filter(_ != 0L),
-        dfDailySupplementsEnzyme = rawRecord.getOptionalNumber("df_s_enzyme").filter(_ != 0L),
-        dfDailySupplementsProbiotics =
-          rawRecord.getOptionalNumber("df_s_probiotics").filter(_ != 0L),
-        dfDailySupplementsFiber = rawRecord.getOptionalNumber("df_s_fiber").filter(_ != 0L),
-        dfDailySupplementsAlkalinize =
-          rawRecord.getOptionalNumber("df_s_alkalinize").filter(_ != 0L),
-        dfDailySupplementsAcidify = rawRecord.getOptionalNumber("df_s_acidify").filter(_ != 0L),
-        dfDailySupplementsTaurine = rawRecord.getOptionalNumber("df_s_taurine").filter(_ != 0L),
-        dfDailySupplementsAntiox = rawRecord.getOptionalNumber("df_s_antiox").filter(_ != 0L),
-        dfDailySupplementsCoenzymeQ10 = rawRecord.getOptionalNumber("df_s_q10").filter(_ != 0L),
+        dfDailySupplementsBoneMeal = rawRecord.getOptionalNumber("df_s_bone_meal"),
+        dfDailySupplementsGlucosamine = rawRecord.getOptionalNumber("df_s_glucosamine"),
+        dfDailySupplementsChondroitin = rawRecord.getOptionalNumber("df_s_chondroitin"),
+        dfDailySupplementsOtherJoint = rawRecord.getOptionalNumber("df_s_joint_other"),
+        dfDailySupplementsOmega3 = rawRecord.getOptionalNumber("df_s_omega3"),
+        dfDailySupplementsNonOilSkin = rawRecord.getOptionalNumber("df_s_skin"),
+        dfDailySupplementsVitamins = rawRecord.getOptionalNumber("df_s_vitamin"),
+        dfDailySupplementsEnzyme = rawRecord.getOptionalNumber("df_s_enzyme"),
+        dfDailySupplementsProbiotics = rawRecord.getOptionalNumber("df_s_probiotics"),
+        dfDailySupplementsFiber = rawRecord.getOptionalNumber("df_s_fiber"),
+        dfDailySupplementsAlkalinize = rawRecord.getOptionalNumber("df_s_alkalinize"),
+        dfDailySupplementsAcidify = rawRecord.getOptionalNumber("df_s_acidify"),
+        dfDailySupplementsTaurine = rawRecord.getOptionalNumber("df_s_taurine"),
+        dfDailySupplementsAntiox = rawRecord.getOptionalNumber("df_s_antiox"),
+        dfDailySupplementsCoenzymeQ10 = rawRecord.getOptionalNumber("df_s_q10"),
         dfDailySupplementsOther = otherSupps,
-        dfDailySupplementsOtherDescription = if (otherSupps.nonEmpty) {
+        dfDailySupplementsOtherDescription = if (otherSupps.getOrElse(0L) != 0L) {
           rawRecord.getOptional("df_s_other_text")
         } else {
           None
@@ -202,41 +197,27 @@ object DietTransformations {
   def mapInfrequentSupplements(rawRecord: RawRecord, dog: HlesDogDiet): HlesDogDiet = {
     val infreqSupps = rawRecord.getRequiredBoolean("df_supplement_ltd")
     if (infreqSupps) {
-      val otherSupps = rawRecord.getOptionalNumber("df_s_other_ltd").filter(_ != 0L)
+      val otherSupps = rawRecord.getOptionalNumber("df_s_other_ltd")
 
       dog.copy(
         dfInfrequentSupplements = Some(infreqSupps),
-        dfInfrequentSupplementsBoneMeal =
-          rawRecord.getOptionalNumber("df_s_bone_meal_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsGlucosamine =
-          rawRecord.getOptionalNumber("df_s_glucosamine_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsChondroitin =
-          rawRecord.getOptionalNumber("df_s_chondroitin_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsOtherJoint =
-          rawRecord.getOptionalNumber("df_s_joint_other_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsOmega3 =
-          rawRecord.getOptionalNumber("df_s_omega3_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsNonOilSkin =
-          rawRecord.getOptionalNumber("df_s_skin_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsVitamins =
-          rawRecord.getOptionalNumber("df_s_vitamin_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsEnzyme =
-          rawRecord.getOptionalNumber("df_s_enzyme_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsProbiotics =
-          rawRecord.getOptionalNumber("df_s_probiotics_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsFiber =
-          rawRecord.getOptionalNumber("df_s_fiber_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsAlkalinize =
-          rawRecord.getOptionalNumber("df_s_alkalinize_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsAcidify =
-          rawRecord.getOptionalNumber("df_s_acidify_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsTaurine =
-          rawRecord.getOptionalNumber("df_s_taurine_ltd").filter(_ != 0L),
-        dfInfrequentSupplementsAntiox =
-          rawRecord.getOptionalNumber("df_s_antiox_ltd").filter(_ != 0L),
+        dfInfrequentSupplementsBoneMeal = rawRecord.getOptionalNumber("df_s_bone_meal_ltd"),
+        dfInfrequentSupplementsGlucosamine = rawRecord.getOptionalNumber("df_s_glucosamine_ltd"),
+        dfInfrequentSupplementsChondroitin = rawRecord.getOptionalNumber("df_s_chondroitin_ltd"),
+        dfInfrequentSupplementsOtherJoint = rawRecord.getOptionalNumber("df_s_joint_other_ltd"),
+        dfInfrequentSupplementsOmega3 = rawRecord.getOptionalNumber("df_s_omega3_ltd"),
+        dfInfrequentSupplementsNonOilSkin = rawRecord.getOptionalNumber("df_s_skin_ltd"),
+        dfInfrequentSupplementsVitamins = rawRecord.getOptionalNumber("df_s_vitamin_ltd"),
+        dfInfrequentSupplementsEnzyme = rawRecord.getOptionalNumber("df_s_enzyme_ltd"),
+        dfInfrequentSupplementsProbiotics = rawRecord.getOptionalNumber("df_s_probiotics_ltd"),
+        dfInfrequentSupplementsFiber = rawRecord.getOptionalNumber("df_s_fiber_ltd"),
+        dfInfrequentSupplementsAlkalinize = rawRecord.getOptionalNumber("df_s_alkalinize_ltd"),
+        dfInfrequentSupplementsAcidify = rawRecord.getOptionalNumber("df_s_acidify_ltd"),
+        dfInfrequentSupplementsTaurine = rawRecord.getOptionalNumber("df_s_taurine_ltd"),
+        dfInfrequentSupplementsAntiox = rawRecord.getOptionalNumber("df_s_antiox_ltd"),
         dfInfrequentSupplementsCoenzymeQ10 = rawRecord.getOptionalNumber("df_s_q10_ltd"),
         dfInfrequentSupplementsOther = otherSupps,
-        dfInfrequentSupplementsOtherDescription = if (otherSupps.nonEmpty) {
+        dfInfrequentSupplementsOtherDescription = if (otherSupps.getOrElse(0L) != 0L) {
           rawRecord.getOptional("df_s_other_ltd_text")
         } else {
           None

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DietTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DietTransformationsSpec.scala
@@ -242,22 +242,22 @@ class DietTransformationsSpec extends AnyFlatSpec with Matchers with OptionValue
     )
 
     out.dfDailySupplements.value shouldBe true
-    out.dfDailySupplementsBoneMeal shouldBe None
+    out.dfDailySupplementsBoneMeal.value shouldBe 0L
     out.dfDailySupplementsGlucosamine.value shouldBe 1L
     out.dfDailySupplementsChondroitin.value shouldBe 2L
-    out.dfDailySupplementsOtherJoint shouldBe None
+    out.dfDailySupplementsOtherJoint.value shouldBe 0L
     out.dfDailySupplementsOmega3.value shouldBe 1L
     out.dfDailySupplementsNonOilSkin.value shouldBe 2L
-    out.dfDailySupplementsVitamins shouldBe None
+    out.dfDailySupplementsVitamins.value shouldBe 0L
     out.dfDailySupplementsEnzyme.value shouldBe 1L
     out.dfDailySupplementsProbiotics.value shouldBe 2L
-    out.dfDailySupplementsFiber shouldBe None
+    out.dfDailySupplementsFiber.value shouldBe 0L
     out.dfDailySupplementsAlkalinize.value shouldBe 1L
     out.dfDailySupplementsAcidify.value shouldBe 2L
-    out.dfDailySupplementsTaurine shouldBe None
+    out.dfDailySupplementsTaurine.value shouldBe 0L
     out.dfDailySupplementsAntiox.value shouldBe 1L
     out.dfDailySupplementsCoenzymeQ10.value shouldBe 2L
-    out.dfDailySupplementsOther shouldBe None
+    out.dfDailySupplementsOther.value shouldBe 0L
     out.dfDailySupplementsOtherDescription shouldBe None
   }
 
@@ -383,22 +383,22 @@ class DietTransformationsSpec extends AnyFlatSpec with Matchers with OptionValue
     )
 
     out.dfInfrequentSupplements.value shouldBe true
-    out.dfInfrequentSupplementsBoneMeal shouldBe None
+    out.dfInfrequentSupplementsBoneMeal.value shouldBe 0L
     out.dfInfrequentSupplementsGlucosamine.value shouldBe 1L
     out.dfInfrequentSupplementsChondroitin.value shouldBe 2L
-    out.dfInfrequentSupplementsOtherJoint shouldBe None
+    out.dfInfrequentSupplementsOtherJoint.value shouldBe 0L
     out.dfInfrequentSupplementsOmega3.value shouldBe 1L
     out.dfInfrequentSupplementsNonOilSkin.value shouldBe 2L
-    out.dfInfrequentSupplementsVitamins shouldBe None
+    out.dfInfrequentSupplementsVitamins.value shouldBe 0L
     out.dfInfrequentSupplementsEnzyme.value shouldBe 1L
     out.dfInfrequentSupplementsProbiotics.value shouldBe 2L
-    out.dfInfrequentSupplementsFiber shouldBe None
+    out.dfInfrequentSupplementsFiber.value shouldBe 0L
     out.dfInfrequentSupplementsAlkalinize.value shouldBe 1L
     out.dfInfrequentSupplementsAcidify.value shouldBe 2L
-    out.dfInfrequentSupplementsTaurine shouldBe None
+    out.dfInfrequentSupplementsTaurine.value shouldBe 0L
     out.dfInfrequentSupplementsAntiox.value shouldBe 1L
     out.dfInfrequentSupplementsCoenzymeQ10.value shouldBe 2L
-    out.dfInfrequentSupplementsOther shouldBe None
+    out.dfInfrequentSupplementsOther.value shouldBe 0L
     out.dfInfrequentSupplementsOtherDescription shouldBe None
   }
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1497)
We were incorrectly suppressing the value for supplement variables if they were 0; we need to pass the 0s through.

## This PR
* Removes unneeded filtering 0 for supplement variables

