### PR TITLE
Un-negate 'without owner' dog activity questions to be 'with owner' instead

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -343,14 +343,14 @@ object ResidentialEnvironmentTransformations {
       deNeighborhoodHasSidewalks = rawRecord.getOptionalNumber("de_sidewalk_yn"),
       deNeighborhoodHasParks = rawRecord.getOptionalBoolean("de_parks_near"),
       deInteractsWithNeighborhoodAnimals = animalsInteract,
-      deInteractsWithNeighborhoodAnimalsWithoutOwner = if (animalsInteract.contains(true)) {
-        rawRecord.getOptionalBoolean("de_animal_interact_present").map(!_)
+      deInteractsWithNeighborhoodAnimalsWithOwner = if (animalsInteract.contains(true)) {
+        rawRecord.getOptionalBoolean("de_animal_interact_present")
       } else {
         None
       },
       deInteractsWithNeighborhoodHumans = humansInteract,
-      deInteractsWithNeighborhoodHumansWithoutOwner = if (humansInteract.contains(true)) {
-        rawRecord.getOptionalBoolean("de_human_interact_present").map(!_)
+      deInteractsWithNeighborhoodHumansWithOwner = if (humansInteract.contains(true)) {
+        rawRecord.getOptionalBoolean("de_human_interact_present")
       } else {
         None
       }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -435,7 +435,7 @@ class ResidentialEnvironmentTransformationsSpec
       "de_sidewalk_yn" -> Array("3"),
       "de_parks_near" -> Array("0"),
       "de_animal_interact" -> Array("1"),
-      "de_animal_interact_present" -> Array("1"),
+      "de_animal_interact_present" -> Array("0"),
       "de_human_interact" -> Array("1"),
       "de_human_interact_present" -> Array("1")
     )
@@ -449,9 +449,9 @@ class ResidentialEnvironmentTransformationsSpec
     output.deNeighborhoodHasSidewalks.value shouldBe 3L
     output.deNeighborhoodHasParks.value shouldBe false
     output.deInteractsWithNeighborhoodAnimals.value shouldBe true
-    output.deInteractsWithNeighborhoodAnimalsWithoutOwner.value shouldBe false
+    output.deInteractsWithNeighborhoodAnimalsWithOwner.value shouldBe false
     output.deInteractsWithNeighborhoodHumans.value shouldBe true
-    output.deInteractsWithNeighborhoodHumansWithoutOwner.value shouldBe false
+    output.deInteractsWithNeighborhoodHumansWithOwner.value shouldBe true
   }
 
   it should "map neighborhood-related fields where there are no neighborhood animal interactions" in {
@@ -459,16 +459,26 @@ class ResidentialEnvironmentTransformationsSpec
       "de_animal_interact" -> Array("0"),
       "de_animal_interact_present" -> Array("1"),
       "de_human_interact" -> Array("0"),
-      "de_human_interact_present" -> Array("1")
+      "de_human_interact_present" -> Array("0")
     )
-    val output =
+    val missingExpectedExampleDogFields = Map[String, Array[String]](
+      "de_animal_interact" -> Array("0"),
+      "de_human_interact" -> Array("0")
+    )
+    val filledOutput =
       ResidentialEnvironmentTransformations.mapResidentialEnvironment(
         RawRecord(id = 1, exampleDogFields)
       )
+    val blankedOutput =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, missingExpectedExampleDogFields)
+      )
 
-    output.deInteractsWithNeighborhoodAnimals.value shouldBe false
-    output.deInteractsWithNeighborhoodAnimalsWithoutOwner shouldBe None
-    output.deInteractsWithNeighborhoodHumans.value shouldBe false
-    output.deInteractsWithNeighborhoodHumansWithoutOwner shouldBe None
+    Seq(filledOutput, blankedOutput).foreach(output => {
+      output.deInteractsWithNeighborhoodAnimals.value shouldBe false
+      output.deInteractsWithNeighborhoodAnimalsWithOwner shouldBe None
+      output.deInteractsWithNeighborhoodHumans.value shouldBe false
+      output.deInteractsWithNeighborhoodHumansWithOwner shouldBe None
+    })
   }
 }

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -346,7 +346,7 @@
       "datatype": "boolean"
     },
     {
-      "name": "de_interacts_with_neighborhood_animals_without_owner",
+      "name": "de_interacts_with_neighborhood_animals_with_owner",
       "datatype": "boolean"
     },
     {
@@ -354,7 +354,7 @@
       "datatype": "boolean"
     },
     {
-      "name": "de_interacts_with_neighborhood_humans_without_owner",
+      "name": "de_interacts_with_neighborhood_humans_with_owner",
       "datatype": "boolean"
     }
   ]


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1495)
* The DAP team requested that we update the "plays with humans without owner present" questions in the dog behavior survey to more closely match the actual wording in Redcap, where they are phrased as "with owner present."

## This PR
* Renames the fields in question from 'without' to 'with'
* Removes the negation we were applying to the boolean in question, to ensure that the resulting data's meaning is unchanged.