### PR TITLE
Update fs_pcvet_email_yn to pass through numeric value of 1/7/8 instead of boolean

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -57,17 +57,17 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     // If there are multiple values
     if (values.--(Array("NA")).size > 1) {
       throw new IllegalStateException(s"Record $id has multiple values for field $field")
-    } else {
-      val toReturn = values.headOption
-
-      val validValue: Boolean =
-        permittedValues.isEmpty || toReturn.map(permittedValues.contains(_)).getOrElse(true)
-      if (!validValue) {
-        throw new IllegalStateException(s"Record $id has invalid value '$toReturn' for field $field")
-      }
-
-      toReturn
     }
+
+    val toReturn = values.headOption
+
+    val validValue: Boolean =
+      permittedValues.isEmpty || toReturn.map(permittedValues.contains(_)).getOrElse(true)
+    if (!validValue) {
+      throw new IllegalStateException(s"Record $id has invalid value '$toReturn' for field $field")
+    }
+
+    toReturn
   }
 
   val sequencesToStrip = List("\r?\n", "\t")

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -29,12 +29,11 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     * If the values are unique, it would error in the same manner it did before
     * If the recurring field contains the same value, the head of the set is used
     */
-  def getRequired(field: String): String = {
-    val values = fields.getOrElse(field, Array.empty)
-    if (values.toSet.size != 1) {
-      throw new IllegalStateException(s"Record $id has more/less than 1 value for field $field")
-    } else {
-      values.head
+  def getRequired(field: String, permittedValues: Set[String] = Set()): String = {
+    getOptional(field, permittedValues) match {
+      case Some(value: String) => value
+      case None =>
+        throw new IllegalStateException(s"Record $id is missing a value for required field $field")
     }
   }
 
@@ -48,19 +47,26 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
     *
     * Only unique duplicates will throw an error
     * If we receive multiple fields with the same value, the head of the set is used
+    *
+    * If permittedValues is provided, raises an error if the value provided is not in the provided list.
+    * Optional values not present in the data are not validated against permittedValues.
+    * An empty set means that all possible values are permitted (a question with no permitted answers would be silly)
     */
-  def getOptional(field: String): Option[String] = {
+  def getOptional(field: String, permittedValues: Set[String] = Set()): Option[String] = {
     val values = fields.getOrElse(field, Array.empty).toSet
     // If there are multiple values
-    if (values.size > 1) {
-      // Filtering out "NA"
-      if (values.--(Array("NA")).size > 1) {
-        throw new IllegalStateException(s"Record $id has multiple values for field $field")
-      } else {
-        values.headOption
-      }
+    if (values.size > 1 && values.--(Array("NA")).size > 1) {
+      throw new IllegalStateException(s"Record $id has multiple values for field $field")
     } else {
-      values.headOption
+      val toReturn = values.headOption
+
+      val validValue: Boolean =
+        permittedValues.isEmpty || toReturn.map(permittedValues.contains(_)).getOrElse(true)
+      if (!validValue) {
+        throw new IllegalStateException(s"Record $id has invalid value '$toReturn' for field $field")
+      }
+
+      toReturn
     }
   }
 
@@ -81,8 +87,12 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   def getOptionalBoolean(field: String): Option[Boolean] = getOptional(field).map(_ == "1")
 
   /** Get the singleton value for an attribute in this record, parsed as a long. */
-  def getOptionalNumber(field: String, truncateDecimals: Boolean = true): Option[Long] =
-    getOptional(field).map(value => {
+  def getOptionalNumber(
+    field: String,
+    truncateDecimals: Boolean = true,
+    permittedValues: Set[Long] = Set()
+  ): Option[Long] =
+    getOptional(field, permittedValues.map(_.toString)).map(value => {
       try {
         value.toLong
       } catch {

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/RawRecord.scala
@@ -55,7 +55,7 @@ case class RawRecord(id: Long, fields: Map[String, Array[String]]) {
   def getOptional(field: String, permittedValues: Set[String] = Set()): Option[String] = {
     val values = fields.getOrElse(field, Array.empty).toSet
     // If there are multiple values
-    if (values.size > 1 && values.--(Array("NA")).size > 1) {
+    if (values.--(Array("NA")).size > 1) {
       throw new IllegalStateException(s"Record $id has multiple values for field $field")
     } else {
       val toReturn = values.headOption

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -15,7 +15,7 @@ object AdditionalStudiesTransformations {
       fsPrimaryCareVeterinarianExists = rawRecord.getOptionalBoolean("fs_pcvet"),
       fsPrimaryCareVeterinarianConsentShareVemr = pcVetConsent,
       fsPrimaryCareVeterinarianCanProvideEmail = pcVetConsent.flatMap {
-        if (_) rawRecord.getOptionalBoolean("fs_pcvet_email_yn") else None
+        if (_) rawRecord.getOptionalNumber("fs_pcvet_email_yn") else None
       },
       fsPrimaryCareVeterinarianState = pcVetConsent.flatMap {
         if (_) rawRecord.getOptional("fs_pcvet_st") else None

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformations.scala
@@ -15,7 +15,9 @@ object AdditionalStudiesTransformations {
       fsPrimaryCareVeterinarianExists = rawRecord.getOptionalBoolean("fs_pcvet"),
       fsPrimaryCareVeterinarianConsentShareVemr = pcVetConsent,
       fsPrimaryCareVeterinarianCanProvideEmail = pcVetConsent.flatMap {
-        if (_) rawRecord.getOptionalNumber("fs_pcvet_email_yn") else None
+        if (_)
+          rawRecord.getOptionalNumber("fs_pcvet_email_yn", permittedValues = Set(1L, 7L, 8L))
+        else None
       },
       fsPrimaryCareVeterinarianState = pcVetConsent.flatMap {
         if (_) rawRecord.getOptional("fs_pcvet_st") else None

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/RawRecordSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/RawRecordSpec.scala
@@ -33,4 +33,22 @@ class RawRecordSpec extends AnyFlatSpec with Matchers {
       "Much has been written about the greatness of Steve[clipped remaining 4098 chars]"
     )
   }
+
+  it should "reject values not in the defined permittedValues" in {
+    val fields =
+      Map("field_one" -> Array("abc123"))
+    val record = RawRecord(789L, fields)
+    an[IllegalStateException] should be thrownBy record.getOptional(
+      "field_one",
+      permittedValues = Set("abc124")
+    )
+  }
+
+  it should "not reject empty or non-empty values if permittedValues is not provided" in {
+    val fields =
+      Map("field_one" -> Array("abc123"))
+    val record = RawRecord(999L, fields)
+    record.getOptional("field_one", permittedValues = Set()) shouldBe Some("abc123")
+    record.getOptional("field_two", permittedValues = Set()) shouldBe None
+  }
 }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/AdditionalStudiesTransformationsSpec.scala
@@ -28,7 +28,34 @@ class AdditionalStudiesTransformationsSpec extends AnyFlatSpec with Matchers wit
     // output of a record with primary care vet consent
     hasConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
     hasConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe true
-    hasConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe 1L
+    hasConsentOut.fsPrimaryCareVeterinarianState.value shouldBe "MA"
+    hasConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 88L
+    hasConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe 87L
+    hasConsentOut.fsGenotypeVsLifespanParticipationLikelihood.value shouldBe 86L
+    hasConsentOut.fsMedicallySlowedAgingParticipationLikelihood.value shouldBe 85L
+  }
+
+  it should "map vet email information properly when fs_pcvet_email_yn is 7" in {
+    val hasConsentExample = Map(
+      "fs_pcvet" -> Array("1"),
+      "fs_pcvet_consent" -> Array("1"),
+      "fs_pcvet_email_yn" -> Array("7"),
+      "fs_pcvet_st" -> Array("MA"),
+      "fs_future_studies" -> Array("88"),
+      "fs_pc_ppf_lifespan" -> Array("87"),
+      "fs_gene_lifespan" -> Array("86"),
+      "fs_med_aging" -> Array("85")
+    )
+
+    val hasConsentOut = AdditionalStudiesTransformations.mapFutureStudies(
+      RawRecord(1, hasConsentExample)
+    )
+
+    // output of a record with primary care vet consent
+    hasConsentOut.fsPrimaryCareVeterinarianExists.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianConsentShareVemr.value shouldBe true
+    hasConsentOut.fsPrimaryCareVeterinarianCanProvideEmail.value shouldBe 7L
     hasConsentOut.fsPrimaryCareVeterinarianState.value shouldBe "MA"
     hasConsentOut.fsFutureStudiesParticipationLikelihood.value shouldBe 88L
     hasConsentOut.fsPhenotypeVsLifespanParticipationLikelihood.value shouldBe 87L

--- a/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_future_studies.fragment.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "fs_primary_care_veterinarian_can_provide_email",
-      "datatype": "boolean"
+      "datatype": "integer"
     },
     {
       "name": "fs_primary_care_veterinarian_state",


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1491)
* We were treating fs_pcvet_email_yn as a boolean value when it has three possible numeric values with distinct meanings.

## This PR
* Switches our internal "vet email" field to a number and updates our code to pass through the provided number unchanged.