### PR TITLE
Pull in upgraded ingest-utils to fix missing docker image

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.6")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1499)
The graalvm docker image we use when building master has been removed.

## This PR
* Pulls in an updated ingest-utils with a fix

