### PR TITLE
Pull correct spay neuter age RC variables

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -141,12 +141,6 @@ object DemographicsTransformations {
     val sex = rawRecord.getOptionalNumber("dd_dog_sex")
     rawRecord.getOptionalBoolean("dd_dog_spay_neuter").fold(dog.copy(ddSex = sex)) {
       spayedOrNeutered =>
-        val spayOrNeuterAge = if (spayedOrNeutered) {
-          rawRecord.getOptionalNumber("dd_spay_or_neuter_age")
-        } else {
-          None
-        }
-
         if (sex.contains(1L)) {
           val siredLitters = if (spayedOrNeutered) {
             rawRecord.getOptionalNumber("dd_ms_sired_yn")
@@ -158,7 +152,7 @@ object DemographicsTransformations {
           dog.copy(
             ddSex = sex,
             ddSpayedOrNeutered = Some(spayedOrNeutered),
-            ddSpayOrNeuterAge = spayOrNeuterAge,
+            ddSpayOrNeuterAge = rawRecord.getOptionalNumber("dd_ms_neuter_age"),
             ddHasSiredLitters = siredLitters,
             ddLitterCount =
               if (siredLitters.contains(1)) rawRecord.getOptionalNumber(litterCountField) else None
@@ -169,7 +163,7 @@ object DemographicsTransformations {
           dog.copy(
             ddSex = sex,
             ddSpayedOrNeutered = Some(spayedOrNeutered),
-            ddSpayOrNeuterAge = spayOrNeuterAge,
+            ddSpayOrNeuterAge = rawRecord.getOptionalNumber("dd_fs_spay_age"),
             ddSpayMethod =
               if (spayedOrNeutered) rawRecord.getOptionalNumber("dd_fs_spay_method") else None,
             ddEstrousCycleExperiencedBeforeSpayed =

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -169,20 +169,20 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     val noLitters = Map[String, Array[String]](
       "dd_dog_sex" -> Array("1"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_ms_neuter_age" -> Array("2"),
       "dd_ms_sired_yn" -> Array("2")
     )
     val litters = Map[String, Array[String]](
       "dd_dog_sex" -> Array("1"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_ms_neuter_age" -> Array("2"),
       "dd_ms_sired_yn" -> Array("1"),
       "dd_mns_nbr_litters_2" -> Array("3")
     )
     val unknown = Map[String, Array[String]](
       "dd_dog_sex" -> Array("1"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_ms_neuter_age" -> Array("2"),
       "dd_ms_sired_yn" -> Array("99")
     )
 
@@ -233,7 +233,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     val unknown = Map[String, Array[String]](
       "dd_dog_sex" -> Array("1"),
       "dd_dog_spay_neuter" -> Array("2"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_ms_neuter_age" -> Array("2"),
       "dd_mns_sired_yn" -> Array("99")
     )
 
@@ -270,7 +270,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     val noLitters = Map[String, Array[String]](
       "dd_dog_sex" -> Array("2"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_fs_spay_age" -> Array("2"),
       "dd_fs_spay_method" -> Array("3"),
       "dd_fs_pregnant" -> Array("2"),
       "dd_fs_heat_yn" -> Array("99")
@@ -278,7 +278,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     val litters = Map[String, Array[String]](
       "dd_dog_sex" -> Array("2"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_fs_spay_age" -> Array("2"),
       "dd_fs_spay_method" -> Array("2"),
       "dd_fs_pregnant" -> Array("1"),
       "dd_fs_nbr_litters" -> Array("3"),
@@ -287,7 +287,7 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     val unknown = Map[String, Array[String]](
       "dd_dog_sex" -> Array("2"),
       "dd_dog_spay_neuter" -> Array("1"),
-      "dd_spay_or_neuter_age" -> Array("2"),
+      "dd_fs_spay_age" -> Array("2"),
       "dd_fs_spay_method" -> Array("1"),
       "dd_fs_pregnant" -> Array("99"),
       "dd_fs_heat_yn" -> Array("1"),


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1487)
We were actually pulling an RC variable that doesn't exist (dd_spay_or_neuter_age). Looked up the correct variables from the DD and Dog Aging Schema mapping doc to pull the correct sex-specific variables.

## This PR

- Removed an unnecessary and redundant variable from the mapSexSpayorNeuter function.
- Correctly pulling out the sex specific variable names for neuter/spay age.