### PR TITLE
Fix comment format

### DIFF
--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -20,7 +20,7 @@ jobs:
         env:
           JVM_OPTS: -Xmx6144m -Xms6144m -Xss16m
       - name: Test
-        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate
+        run: sbt "set ThisBuild/coverageEnabled := true" test IntegrationTest/test coverageAggregate doc
         env:
           VAULT_ADDR: ${{ secrets.VaultAddress }}
           VAULT_ROLE_ID: ${{ secrets.VaultRoleId }}

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -267,9 +267,7 @@ object DemographicsTransformations {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
     def activityLevel(activity: String): Option[Long] = {
-      /**
-        * Gets activity level regardless of activities_m check
-        */
+      // Gets activity level regardless of activities_m check
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
         case None =>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -267,8 +267,7 @@ object DemographicsTransformations {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
     def activityLevel(activity: String): Option[Long] = {
-      /** Gets activity level regardless of activities_m check
-        */
+      // gets activity level regardless of activities_m check
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
         case None =>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -267,7 +267,8 @@ object DemographicsTransformations {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
     def activityLevel(activity: String): Option[Long] = {
-      // gets activity level regardless of activities_m check
+      /** Gets activity level regardless of activities_m check
+        */
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
         case None =>

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -267,7 +267,8 @@ object DemographicsTransformations {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
     def activityLevel(activity: String): Option[Long] = {
-      // Gets activity level regardless of activities_m check
+      /** Gets activity level regardless of activities_m check
+        */
       rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
         case Some(value) => Some(value)
         case None =>


### PR DESCRIPTION
## Why

Master is failing due to scaladoc not liking the format of this comment.

## This PR
* Reformats the comment
* Adds `doc` to the `validate-pull-request` GH action so we can catch these issues in CI before they reach master
