### PR TITLE
Rename Stuffed Toys

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformations.scala
@@ -217,8 +217,8 @@ object RoutineEnvironmentTransformations {
       dog.copy(
         deRoutineToys = toys,
         deRoutineToysIncludePlastic = rawRecord.getOptionalNumber("de_toy_plastic"),
-        deRoutineToysIncludeStuffedFabric = rawRecord.getOptionalNumber("de_toy_fabric_stuffed"),
-        deRoutineToysIncludeUnstuffedFabric =
+        deRoutineToysIncludeFabricStuffed = rawRecord.getOptionalNumber("de_toy_fabric_stuffed"),
+        deRoutineToysIncludeFabricUnstuffed =
           rawRecord.getOptionalNumber("de_toy_fabric_unstuffed"),
         deRoutineToysIncludeRubber = rawRecord.getOptionalNumber("de_toy_rubber"),
         deRoutineToysIncludeMetal = rawRecord.getOptionalNumber("de_toy_metal"),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/RoutineEnvironmentTransformationsSpec.scala
@@ -413,8 +413,8 @@ class RoutineEnvironmentTransformationsSpec extends AnyFlatSpec with Matchers wi
 
     output1.deRoutineToys.value shouldBe true
     output1.deRoutineToysIncludePlastic.value shouldBe 1
-    output1.deRoutineToysIncludeStuffedFabric.value shouldBe 0
-    output1.deRoutineToysIncludeUnstuffedFabric.value shouldBe 1
+    output1.deRoutineToysIncludeFabricStuffed.value shouldBe 0
+    output1.deRoutineToysIncludeFabricUnstuffed.value shouldBe 1
     output1.deRoutineToysIncludeRubber.value shouldBe 0
     output1.deRoutineToysIncludeMetal.value shouldBe 1
     output1.deRoutineToysIncludeAnimalProducts.value shouldBe 0
@@ -449,8 +449,8 @@ class RoutineEnvironmentTransformationsSpec extends AnyFlatSpec with Matchers wi
 
     output2.deRoutineToys.value shouldBe true
     output2.deRoutineToysIncludePlastic.value shouldBe 0
-    output2.deRoutineToysIncludeStuffedFabric.value shouldBe 1
-    output2.deRoutineToysIncludeUnstuffedFabric.value shouldBe 0
+    output2.deRoutineToysIncludeFabricStuffed.value shouldBe 1
+    output2.deRoutineToysIncludeFabricUnstuffed.value shouldBe 0
     output2.deRoutineToysIncludeRubber.value shouldBe 1
     output2.deRoutineToysIncludeMetal.value shouldBe 0
     output2.deRoutineToysIncludeAnimalProducts.value shouldBe 1

--- a/schema/src/main/jade-fragments/hles_dog_routine_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_routine_environment.fragment.json
@@ -218,11 +218,11 @@
       "datatype": "integer"
     },
     {
-      "name": "de_routine_toys_include_stuffed_fabric",
+      "name": "de_routine_toys_include_fabric_stuffed",
       "datatype": "integer"
     },
     {
-      "name": "de_routine_toys_include_unstuffed_fabric",
+      "name": "de_routine_toys_include_fabric_unstuffed",
       "datatype": "integer"
     },
     {


### PR DESCRIPTION
## Why
Renamed 2 variables to align with RedCap Variable Names
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1420)

## This PR

- Renamed 2 variables to align with RedCap naming convention within the hles_dog_routine_environment fragment.
- Updated schema, transformation code, and unit tests for "de_routine_toys_include_fabric_stuffed" and "de_routine_toys_include_fabric_unstuffed".