### PR TITLE
Undo changes to activity parser

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -262,18 +262,12 @@ object DemographicsTransformations {
   def mapActivities(rawRecord: RawRecord, dog: HlesDogDemographics): HlesDogDemographics = {
     val allActivities = rawRecord.getArray("dd_activities").map(_.toLong)
 
-    def activityLevel(activity: String): Option[Long] = {
-      // gets activity level regardless of activities_m check
-      rawRecord.getOptionalNumber(s"dd_${activity}_m") match {
-        case Some(value) => Some(value)
-        case None =>
-          if (allActivities.contains[Long](ActivityValues(activity))) {
-            Some(3L)
-          } else {
-            None
-          }
+    def activityLevel(activity: String): Option[Long] =
+      if (allActivities.contains[Long](ActivityValues(activity))) {
+        rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(Some(3L))
+      } else {
+        None
       }
-    }
 
     val serviceLevel = activityLevel("service")
     val assistanceLevel = activityLevel("assistance")

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -535,23 +535,4 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     assistanceOut.ddActivitiesServiceOtherDescription.value shouldBe "Activity!"
 
   }
-  it should "map activity-related fallback fields" in {
-    val activitiesDog = Map[String, Array[String]](
-      "dd_activities" -> Array("3", "5", "7", "9", "11", "98"),
-      "dd_assistance_m" -> Array("2"),
-      "dd_other_m" -> Array("1"),
-      "dd_companion_m" -> Array("1"),
-      "dd_1st_activity_other" -> Array("Activity?"),
-      "dd_service_type_1" -> Array("2", "4", "6", "98"),
-      "dd_service_medical_other_1" -> Array("Medical!"),
-      "dd_service_other_1" -> Array("Activity!")
-    )
-
-    val activitiesOut = DemographicsTransformations.mapActivities(
-      RawRecord(1, activitiesDog),
-      HlesDogDemographics.init()
-    )
-
-    activitiesOut.ddActivitiesCompanionAnimal.value shouldBe 1L
-  }
 }


### PR DESCRIPTION
## Why
DAP folks decided our original logic was simple and handles their edge case better than the changes they proposed.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1473)

## This PR
- Removed recent changes to pull activity level "dd_${activity}_m" regardless of check
- Removed no longer necessary unit test case.
