### PR TITLE
Add new columns for past country residence

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -28,12 +28,12 @@ object ResidentialEnvironmentTransformations {
     * de_country_[n] is the deprecated user entry free text field
     * de_country_[n]_dd is the updated drop down option list
     */
-  def parseCountry(
+  def parseOnlyCountry(
     rawRecord: RawRecord,
-    countryField: String,
-    countryFieldDropdown: String
+    multipleAdd: String,
+    only1Add: String
   ): Option[String] = {
-    rawRecord.getOptional(countryField).orElse(rawRecord.getOptional(countryFieldDropdown))
+    rawRecord.getOptional(multipleAdd).orElse(rawRecord.getOptional(only1Add))
   }
 
   /**
@@ -58,38 +58,52 @@ object ResidentialEnvironmentTransformations {
           deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
           dePastResidenceZipCount = Some(pastZipCount),
           dePastResidenceCountryCount = Some(pastCountryCount),
-          dePastResidenceCountry1 = if (pastCountryCount > 1) {
-            parseCountry(rawRecord, "de_country_01", "de_country_01_dd")
-          } else {
-            parseCountry(rawRecord, "de_country_01_only", "de_country_01_only_dd")
-          },
+          dePastResidenceCountry1 =
+            if (pastCountryCount > 1)
+              rawRecord.getOptional(
+                "de_country_01_dd"
+              ),
           dePastResidenceCountry2 =
-            if (pastCountryCount > 1) parseCountry(rawRecord, "de_country_02", "de_country_02_dd")
-            else None,
+            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02_dd"),
           dePastResidenceCountry3 =
-            if (pastCountryCount > 2) parseCountry(rawRecord, "de_country_03", "de_country_03_dd")
-            else None,
+            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03_dd"),
           dePastResidenceCountry4 =
-            if (pastCountryCount > 3) parseCountry(rawRecord, "de_country_04", "de_country_04_dd")
-            else None,
+            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04_dd"),
           dePastResidenceCountry5 =
-            if (pastCountryCount > 4) parseCountry(rawRecord, "de_country_05", "de_country_05_dd")
-            else None,
+            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05_dd"),
           dePastResidenceCountry6 =
-            if (pastCountryCount > 5) parseCountry(rawRecord, "de_country_06", "de_country_06_dd")
-            else None,
+            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06_dd"),
           dePastResidenceCountry7 =
-            if (pastCountryCount > 6) parseCountry(rawRecord, "de_country_07", "de_country_07_dd")
-            else None,
+            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07_dd"),
           dePastResidenceCountry8 =
-            if (pastCountryCount > 7) parseCountry(rawRecord, "de_country_08", "de_country_08_dd")
-            else None,
+            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08_dd"),
           dePastResidenceCountry9 =
-            if (pastCountryCount > 8) parseCountry(rawRecord, "de_country_09", "de_country_09_dd")
-            else None,
+            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09_dd"),
           dePastResidenceCountry10 =
-            if (pastCountryCount > 9) parseCountry(rawRecord, "de_country_10", "de_country_10_dd")
-            else None
+            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10_dd"),
+          dePastResidenceCountry1Text =
+            if (pastCountryCount > 1)
+              rawRecord
+                .getOptional("de_country_01")
+                .orElse(rawRecord.getOptional("de_country_01_only")),
+          dePastResidenceCountry2Text =
+            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02"),
+          dePastResidenceCountry3Text =
+            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03"),
+          dePastResidenceCountry4Text =
+            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04"),
+          dePastResidenceCountry5Text =
+            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05"),
+          dePastResidenceCountry6Text =
+            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06"),
+          dePastResidenceCountry7Text =
+            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07"),
+          dePastResidenceCountry8Text =
+            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08"),
+          dePastResidenceCountry9Text =
+            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09"),
+          dePastResidenceCountry10Text =
+            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10")
         )
       }
   }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -24,21 +24,25 @@ object ResidentialEnvironmentTransformations {
   }
 
   /**
-    * Parse both country fields for a RedCap record,
-    * de_country_[n] is the deprecated user entry free text field
-    * de_country_[n]_dd is the updated drop down option list
+    * Checks for a given alternate residence country, gated with a check on residence count
+    * pastCountryCount arg is the RC variable "de_country_nbr"
+    * countryCounter arg is the sequence number for the supplied RC variable (next arg)
+    * countryField arg is the RC past residence country we are currently checking
     */
-  def parseOnlyCountry(
+  def getPastResidenceCountry(
     rawRecord: RawRecord,
-    multipleAdd: String,
-    only1Add: String
+    pastCountryCount: Long,
+    countryCounter: Long,
+    countryField: String
   ): Option[String] = {
-    rawRecord.getOptional(multipleAdd).orElse(rawRecord.getOptional(only1Add))
+    if (pastCountryCount > countryCounter) rawRecord.getOptional(countryField) else None
   }
 
   /**
     * Parse all past-residence-related fields out of a raw RedCap record,
     * injecting them into a partially-modeled dog record.
+    * de_country_[n] is the deprecated user entry free text field
+    * de_country_[n]_dd is the updated drop down option list
     */
   def mapPastResidences(
     rawRecord: RawRecord,
@@ -58,6 +62,7 @@ object ResidentialEnvironmentTransformations {
           deLifetimeResidenceCount = Some(pastResidenceCount + currentResidenceCount.getOrElse(0L)),
           dePastResidenceZipCount = Some(pastZipCount),
           dePastResidenceCountryCount = Some(pastCountryCount),
+          // there are two separate fields to check for "First country"
           dePastResidenceCountry1 =
             if (pastCountryCount > 1)
               rawRecord
@@ -65,23 +70,24 @@ object ResidentialEnvironmentTransformations {
                 .orElse(rawRecord.getOptional("de_country_01_only_dd"))
             else None,
           dePastResidenceCountry2 =
-            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02_dd"),
           dePastResidenceCountry3 =
-            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 3L, "de_country_03_dd"),
           dePastResidenceCountry4 =
-            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 4L, "de_country_04_dd"),
           dePastResidenceCountry5 =
-            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 5L, "de_country_05_dd"),
           dePastResidenceCountry6 =
-            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 6L, "de_country_06_dd"),
           dePastResidenceCountry7 =
-            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 7L, "de_country_07_dd"),
           dePastResidenceCountry8 =
-            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 8L, "de_country_08_dd"),
           dePastResidenceCountry9 =
-            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 9L, "de_country_09_dd"),
           dePastResidenceCountry10 =
-            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10_dd") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 10L, "de_country_10_dd"),
+          // there are two separate fields to check for "First country"
           dePastResidenceCountry1Text =
             if (pastCountryCount > 1)
               rawRecord
@@ -89,23 +95,23 @@ object ResidentialEnvironmentTransformations {
                 .orElse(rawRecord.getOptional("de_country_01_only"))
             else None,
           dePastResidenceCountry2Text =
-            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02"),
           dePastResidenceCountry3Text =
-            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 3L, "de_country_03"),
           dePastResidenceCountry4Text =
-            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 4L, "de_country_04"),
           dePastResidenceCountry5Text =
-            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 5L, "de_country_05"),
           dePastResidenceCountry6Text =
-            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 6L, "de_country_06"),
           dePastResidenceCountry7Text =
-            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 7L, "de_country_07"),
           dePastResidenceCountry8Text =
-            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 8L, "de_country_08"),
           dePastResidenceCountry9Text =
-            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09") else None,
+            getPastResidenceCountry(rawRecord, pastCountryCount, 9L, "de_country_09"),
           dePastResidenceCountry10Text =
-            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10") else None
+            getPastResidenceCountry(rawRecord, pastCountryCount, 10L, "de_country_10")
         )
       }
   }

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -60,50 +60,52 @@ object ResidentialEnvironmentTransformations {
           dePastResidenceCountryCount = Some(pastCountryCount),
           dePastResidenceCountry1 =
             if (pastCountryCount > 1)
-              rawRecord.getOptional(
-                "de_country_01_dd"
-              ),
+              rawRecord
+                .getOptional("de_country_01_dd")
+                .orElse(rawRecord.getOptional("de_country_01_only_dd"))
+            else None,
           dePastResidenceCountry2 =
-            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02_dd"),
+            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02_dd") else None,
           dePastResidenceCountry3 =
-            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03_dd"),
+            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03_dd") else None,
           dePastResidenceCountry4 =
-            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04_dd"),
+            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04_dd") else None,
           dePastResidenceCountry5 =
-            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05_dd"),
+            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05_dd") else None,
           dePastResidenceCountry6 =
-            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06_dd"),
+            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06_dd") else None,
           dePastResidenceCountry7 =
-            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07_dd"),
+            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07_dd") else None,
           dePastResidenceCountry8 =
-            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08_dd"),
+            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08_dd") else None,
           dePastResidenceCountry9 =
-            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09_dd"),
+            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09_dd") else None,
           dePastResidenceCountry10 =
-            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10_dd"),
+            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10_dd") else None,
           dePastResidenceCountry1Text =
             if (pastCountryCount > 1)
               rawRecord
                 .getOptional("de_country_01")
-                .orElse(rawRecord.getOptional("de_country_01_only")),
+                .orElse(rawRecord.getOptional("de_country_01_only"))
+            else None,
           dePastResidenceCountry2Text =
-            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02"),
+            if (pastCountryCount > 2) rawRecord.getOptional("de_country_02") else None,
           dePastResidenceCountry3Text =
-            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03"),
+            if (pastCountryCount > 3) rawRecord.getOptional("de_country_03") else None,
           dePastResidenceCountry4Text =
-            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04"),
+            if (pastCountryCount > 4) rawRecord.getOptional("de_country_04") else None,
           dePastResidenceCountry5Text =
-            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05"),
+            if (pastCountryCount > 5) rawRecord.getOptional("de_country_05") else None,
           dePastResidenceCountry6Text =
-            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06"),
+            if (pastCountryCount > 6) rawRecord.getOptional("de_country_06") else None,
           dePastResidenceCountry7Text =
-            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07"),
+            if (pastCountryCount > 7) rawRecord.getOptional("de_country_07") else None,
           dePastResidenceCountry8Text =
-            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08"),
+            if (pastCountryCount > 8) rawRecord.getOptional("de_country_08") else None,
           dePastResidenceCountry9Text =
-            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09"),
+            if (pastCountryCount > 9) rawRecord.getOptional("de_country_09") else None,
           dePastResidenceCountry10Text =
-            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10")
+            if (pastCountryCount > 10) rawRecord.getOptional("de_country_10") else None
         )
       }
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -16,7 +16,7 @@ class ResidentialEnvironmentTransformationsSpec
       "de_home_nbr" -> Array("10"),
       "de_zip_nbr" -> Array("10"),
       "oc_address2_yn" -> Array("1"),
-      "de_country_nbr" -> Array("10"),
+      "de_country_nbr" -> Array("11"),
       "de_country_01_only" -> Array("this should be ignored too"),
       "de_country_01" -> Array("country1"),
       "de_country_02_dd" -> Array("country2"),
@@ -36,7 +36,7 @@ class ResidentialEnvironmentTransformationsSpec
 
     output.deLifetimeResidenceCount.value shouldBe 12
     output.dePastResidenceZipCount.value shouldBe 10
-    output.dePastResidenceCountryCount.value shouldBe 10
+    output.dePastResidenceCountryCount.value shouldBe 11
     output.dePastResidenceCountry1Text.value shouldBe "country1"
     output.dePastResidenceCountry2.value shouldBe "country2"
     output.dePastResidenceCountry3.value shouldBe "country3"
@@ -54,9 +54,9 @@ class ResidentialEnvironmentTransformationsSpec
       "de_home_nbr" -> Array("1"),
       "de_zip_nbr" -> Array("1"),
       "oc_address2_yn" -> Array("0"),
-      "de_country_nbr" -> Array("1"),
-      "de_country_01_only" -> Array("USA!"),
-      "de_country_01" -> Array("this should be ignored"),
+      "de_country_nbr" -> Array("2"),
+      "de_country_01_only" -> Array("this should be ignored"),
+      "de_country_01" -> Array("USA!"),
       "de_country_02" -> Array("IgnoredCountry")
     )
     val output =
@@ -66,7 +66,7 @@ class ResidentialEnvironmentTransformationsSpec
 
     output.deLifetimeResidenceCount.value shouldBe 2
     output.dePastResidenceZipCount.value shouldBe 1
-    output.dePastResidenceCountryCount.value shouldBe 1
+    output.dePastResidenceCountryCount.value shouldBe 2
     output.dePastResidenceCountry1Text.value shouldBe "USA!"
     output.dePastResidenceCountry2 shouldBe None
   }
@@ -76,7 +76,7 @@ class ResidentialEnvironmentTransformationsSpec
       "de_home_nbr" -> Array("1"),
       "de_zip_nbr" -> Array("1"),
       "oc_address2_yn" -> Array("0"),
-      "de_country_nbr" -> Array("1"),
+      "de_country_nbr" -> Array("2"),
       "de_country_01_only_dd" -> Array("US"),
       "de_country_01" -> Array("this should be ignored"),
       "de_country_02" -> Array("IgnoredCountry")
@@ -88,7 +88,7 @@ class ResidentialEnvironmentTransformationsSpec
 
     output.deLifetimeResidenceCount.value shouldBe 2
     output.dePastResidenceZipCount.value shouldBe 1
-    output.dePastResidenceCountryCount.value shouldBe 1
+    output.dePastResidenceCountryCount.value shouldBe 2
     output.dePastResidenceCountry1.value shouldBe "US"
     output.dePastResidenceCountry2 shouldBe None
   }

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -37,15 +37,15 @@ class ResidentialEnvironmentTransformationsSpec
     output.deLifetimeResidenceCount.value shouldBe 12
     output.dePastResidenceZipCount.value shouldBe 10
     output.dePastResidenceCountryCount.value shouldBe 10
-    output.dePastResidenceCountry1.value shouldBe "country1"
+    output.dePastResidenceCountry1Text.value shouldBe "country1"
     output.dePastResidenceCountry2.value shouldBe "country2"
     output.dePastResidenceCountry3.value shouldBe "country3"
-    output.dePastResidenceCountry4.value shouldBe "country4"
-    output.dePastResidenceCountry5.value shouldBe "country5"
-    output.dePastResidenceCountry6.value shouldBe "country6"
-    output.dePastResidenceCountry7.value shouldBe "country7"
+    output.dePastResidenceCountry4Text.value shouldBe "country4"
+    output.dePastResidenceCountry5Text.value shouldBe "country5"
+    output.dePastResidenceCountry6Text.value shouldBe "country6"
+    output.dePastResidenceCountry7Text.value shouldBe "country7"
     output.dePastResidenceCountry8.value shouldBe "country8"
-    output.dePastResidenceCountry9.value shouldBe "country9"
+    output.dePastResidenceCountry9Text.value shouldBe "country9"
     output.dePastResidenceCountry10.value shouldBe "country10"
   }
 
@@ -67,7 +67,7 @@ class ResidentialEnvironmentTransformationsSpec
     output.deLifetimeResidenceCount.value shouldBe 2
     output.dePastResidenceZipCount.value shouldBe 1
     output.dePastResidenceCountryCount.value shouldBe 1
-    output.dePastResidenceCountry1.value shouldBe "USA!"
+    output.dePastResidenceCountry1Text.value shouldBe "USA!"
     output.dePastResidenceCountry2 shouldBe None
   }
 

--- a/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
+++ b/schema/src/main/jade-fragments/hles_dog_residential_environment.fragment.json
@@ -54,6 +54,46 @@
       "datatype": "string"
     },
     {
+      "name": "de_past_residence_country1_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country2_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country3_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country4_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country5_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country6_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country7_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country8_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country9_text",
+      "datatype": "string"
+    },
+    {
+      "name": "de_past_residence_country10_text",
+      "datatype": "string"
+    },
+    {
       "name": "de_home_area_type",
       "datatype": "integer"
     },


### PR DESCRIPTION
## Why
DAP has 10 fields to get the alternate past residence country for a participant.
They initially were allowing users to enter their own text strings and have since deprecated that field and are now providing a dropdown to choose a country form. In our old logic we were checking both. DAP has requested that we add 10 columns for the "text entry" past residences.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1484)

## This PR
- Added 10 new fields to the ResidentialEnvironmentTransformations
- Modified the parseCountry to beck for both the  "_01" vs "_01_only" RC variables
- Updated unit tests