### PR TITLE
Fix response value used to indicate 'no alternative care' in health status transforms

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformations.scala
@@ -109,7 +109,7 @@ object HealthStatusTransformations {
     val otherAltCare = altCareMethods.map(_.contains("98"))
 
     dog.copy(
-      hsAlternativeCareNone = altCareMethods.map(_.contains("0")),
+      hsAlternativeCareNone = altCareMethods.map(_.contains("99")),
       hsAlternativeCareAcupuncture = altCareMethods.map(_.contains("1")),
       hsAlternativeCareHerbalMedicine = altCareMethods.map(_.contains("2")),
       hsAlternativeCareHomeopathy = altCareMethods.map(_.contains("3")),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/HealthStatusTransformationsSpec.scala
@@ -134,4 +134,27 @@ class HealthStatusTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     out.hsAlternativeCareOther.value shouldBe true
     out.hsAlternativeCareOtherDescription.value shouldBe "Voodoo"
   }
+
+  it should "pick up 'none of the above' for alternative care" in {
+    val example = Map(
+      "hs_other_health_care" -> Array("99")
+    )
+
+    val out = HealthStatusTransformations.mapAltCare(
+      RawRecord(1, example),
+      HlesDogHealthSummary.init()
+    )
+
+    out.hsAlternativeCareNone.value shouldBe true
+    out.hsAlternativeCareAcupuncture.value shouldBe false
+    out.hsAlternativeCareHerbalMedicine.value shouldBe false
+    out.hsAlternativeCareHomeopathy.value shouldBe false
+    out.hsAlternativeCareChiropractic.value shouldBe false
+    out.hsAlternativeCareMassage.value shouldBe false
+    out.hsAlternativeCareRehabilitationTherapy.value shouldBe false
+    out.hsAlternativeCareReiki.value shouldBe false
+    out.hsAlternativeCareTraditionalChineseMedicine.value shouldBe false
+    out.hsAlternativeCareOther.value shouldBe false
+    out.hsAlternativeCareOtherDescription shouldBe None
+  }
 }


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1520)

* We were using the number 0 to indicate that a dog hadn't received medical care from any type of wizard, but according to the codebook, the value to indicate that is 99

## This PR