### PR TITLE
Expanded integration tests for DAP extraction pipeline

### DIFF
--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -25,7 +25,8 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
       pullDataDictionaries = false
     )
 
-  val expectedStudyIds = List("id_one", "id_two")
+  val fakeIds = 0 to 1
+  val expectedStudyIds = fakeIds.map { id => s"id_${id}" }.toList
 
   val studyIdsRequest = RedcapRequestGeneratorParams(
     testArgs.apiToken,
@@ -69,8 +70,6 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   it should "successfully download records from RedCap" in {
     readMsgs(hlesOutputDir, "records/*.json") shouldNot be(empty)
   }
-
-  val fakeIds = 0 to 1
 
   val expectedPackDateRecord: Seq[Obj] = fakeIds.map { i =>
     Obj(

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -71,21 +71,24 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   }
 
   val fakeIds = 0 to 1
-  val expectedPackDateRecord: Seq[Obj] = fakeIds.map{ i =>
+
+  val expectedPackDateRecord: Seq[Obj] = fakeIds.map { i =>
     Obj(
       Str("record") -> Str(i.toString),
       Str("field_name") -> Str("st_dap_pack_date"),
-      Str("value") -> Str("2019-04-04"),
+      Str("value") -> Str("2019-04-04")
     )
   }
-  val expectedPackCountRecord: Seq[Obj] = fakeIds.map{ i =>
+
+  val expectedPackCountRecord: Seq[Obj] = fakeIds.map { i =>
     Obj(
       Str("record") -> Str(i.toString),
       Str("field_name") -> Str("st_dap_pack_count"),
       Str("value") -> Str("2")
     )
   }
-  val expectedConsentRecord: Seq[Obj] = fakeIds.map{ i =>
+
+  val expectedConsentRecord: Seq[Obj] = fakeIds.map { i =>
     Obj(
       Str("record") -> Str(i.toString),
       Str("field_name") -> Str("co_consent"),

--- a/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
+++ b/hles/extraction/src/test/scala/org/broadinstitute/monster/dap/HLESExtractionPipelineBuilderIntegrationSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.monster.dap
 
 import java.time.{LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
-
 import better.files.File
 import org.broadinstitute.monster.common.PipelineBuilderSpec
 
@@ -69,4 +68,28 @@ class HLESExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[A
   it should "successfully download records from RedCap" in {
     readMsgs(hlesOutputDir, "records/*.json") shouldNot be(empty)
   }
+
+  it should "contain records that all have a record, field_name, and value key" in {
+    readMsgs(hlesOutputDir, "records/*.json").foreach(msg => {
+      val record = msg.obj.toString()
+      record.contains("record") shouldBe true
+      record.contains("field_name") shouldBe true
+      record.contains("value") shouldBe true
+    })
+  }
+
+  it should "contain records with expected valid fields" in {
+    val allRecords = (readMsgs(hlesOutputDir, "records/*.json")).toString()
+    print(allRecords)
+    allRecords.contains("record") shouldBe true
+    allRecords.contains("1") shouldBe true
+    allRecords.contains("st_dap_pack_date") shouldBe true
+    allRecords.contains("2019-04-04") shouldBe true
+    allRecords.contains("field_name") shouldBe true
+    allRecords.contains("st_dap_pack_count") shouldBe true
+    allRecords.contains("co_consent") shouldBe true
+    allRecords.contains("value") shouldBe true
+    allRecords.contains("2") shouldBe true
+  }
+
 }


### PR DESCRIPTION
## Why
Our integration tests for DAP extraction pipeline did not extend beyond checking if the json file downloaded was not empty

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1419)

## This PR
Adds tests to make sure that each record has a record, field_name, and value key and a test to check expected fields with their expected values
