### PR TITLE
update logic and tests for single past country

### DIFF
--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -64,11 +64,9 @@ object ResidentialEnvironmentTransformations {
           dePastResidenceCountryCount = Some(pastCountryCount),
           // there are two separate fields to check for "First country"
           dePastResidenceCountry1 =
-            if (pastCountryCount > 1)
-              rawRecord.getOptional("de_country_01_dd")
-            else if (pastCountryCount == 1)
+            if (pastCountryCount == 1)
               rawRecord.getOptional("de_country_01_only_dd")
-            else None,
+            else getPastResidenceCountry(rawRecord, pastCountryCount, 1L, "de_country_01_dd"),
           dePastResidenceCountry2 =
             getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02_dd"),
           dePastResidenceCountry3 =
@@ -89,12 +87,10 @@ object ResidentialEnvironmentTransformations {
             getPastResidenceCountry(rawRecord, pastCountryCount, 10L, "de_country_10_dd"),
           // there are two separate fields to check for "First country"
           dePastResidenceCountry1Text =
-            if (pastCountryCount > 1)
+            if (pastCountryCount == 1)
               rawRecord
-                .getOptional("de_country_01")
-            else if (pastCountryCount == 1)
-              rawRecord.getOptional("de_country_01_only")
-            else None,
+                .getOptional("de_country_01_only")
+            else getPastResidenceCountry(rawRecord, pastCountryCount, 1L, "de_country_01"),
           dePastResidenceCountry2Text =
             getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02"),
           dePastResidenceCountry3Text =

--- a/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
+++ b/hles/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformations.scala
@@ -65,9 +65,9 @@ object ResidentialEnvironmentTransformations {
           // there are two separate fields to check for "First country"
           dePastResidenceCountry1 =
             if (pastCountryCount > 1)
-              rawRecord
-                .getOptional("de_country_01_dd")
-                .orElse(rawRecord.getOptional("de_country_01_only_dd"))
+              rawRecord.getOptional("de_country_01_dd")
+            else if (pastCountryCount == 1)
+              rawRecord.getOptional("de_country_01_only_dd")
             else None,
           dePastResidenceCountry2 =
             getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02_dd"),
@@ -92,7 +92,8 @@ object ResidentialEnvironmentTransformations {
             if (pastCountryCount > 1)
               rawRecord
                 .getOptional("de_country_01")
-                .orElse(rawRecord.getOptional("de_country_01_only"))
+            else if (pastCountryCount == 1)
+              rawRecord.getOptional("de_country_01_only")
             else None,
           dePastResidenceCountry2Text =
             getPastResidenceCountry(rawRecord, pastCountryCount, 2L, "de_country_02"),

--- a/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
+++ b/hles/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/ResidentialEnvironmentTransformationsSpec.scala
@@ -54,30 +54,8 @@ class ResidentialEnvironmentTransformationsSpec
       "de_home_nbr" -> Array("1"),
       "de_zip_nbr" -> Array("1"),
       "oc_address2_yn" -> Array("0"),
-      "de_country_nbr" -> Array("2"),
-      "de_country_01_only" -> Array("this should be ignored"),
-      "de_country_01" -> Array("USA!"),
-      "de_country_02" -> Array("IgnoredCountry")
-    )
-    val output =
-      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
-        RawRecord(id = 1, exampleDogFields)
-      )
-
-    output.deLifetimeResidenceCount.value shouldBe 2
-    output.dePastResidenceZipCount.value shouldBe 1
-    output.dePastResidenceCountryCount.value shouldBe 2
-    output.dePastResidenceCountry1Text.value shouldBe "USA!"
-    output.dePastResidenceCountry2 shouldBe None
-  }
-
-  it should "map past-residence-related fields where there is a single past and current home (dropdown)" in {
-    val exampleDogFields = Map[String, Array[String]](
-      "de_home_nbr" -> Array("1"),
-      "de_zip_nbr" -> Array("1"),
-      "oc_address2_yn" -> Array("0"),
-      "de_country_nbr" -> Array("2"),
-      "de_country_01_only_dd" -> Array("US"),
+      "de_country_nbr" -> Array("1"),
+      "de_country_01_only" -> Array("USA!"),
       "de_country_01" -> Array("this should be ignored"),
       "de_country_02" -> Array("IgnoredCountry")
     )
@@ -88,7 +66,29 @@ class ResidentialEnvironmentTransformationsSpec
 
     output.deLifetimeResidenceCount.value shouldBe 2
     output.dePastResidenceZipCount.value shouldBe 1
-    output.dePastResidenceCountryCount.value shouldBe 2
+    output.dePastResidenceCountryCount.value shouldBe 1
+    output.dePastResidenceCountry1Text.value shouldBe "USA!"
+    output.dePastResidenceCountry2 shouldBe None
+  }
+
+  it should "map past-residence-related fields where there is a single past and current home (dropdown)" in {
+    val exampleDogFields = Map[String, Array[String]](
+      "de_home_nbr" -> Array("1"),
+      "de_zip_nbr" -> Array("1"),
+      "oc_address2_yn" -> Array("0"),
+      "de_country_nbr" -> Array("1"),
+      "de_country_01_only_dd" -> Array("US"),
+      "de_country_01_dd" -> Array("this should be ignored"),
+      "de_country_02" -> Array("IgnoredCountry")
+    )
+    val output =
+      ResidentialEnvironmentTransformations.mapResidentialEnvironment(
+        RawRecord(id = 1, exampleDogFields)
+      )
+
+    output.deLifetimeResidenceCount.value shouldBe 2
+    output.dePastResidenceZipCount.value shouldBe 1
+    output.dePastResidenceCountryCount.value shouldBe 1
     output.dePastResidenceCountry1.value shouldBe "US"
     output.dePastResidenceCountry2 shouldBe None
   }


### PR DESCRIPTION
## Why
Looks like there is a small bug in what country is pulled if there is only one other country of residence prior to the current residence (see relevant ticket).

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1521?atlOrigin=eyJpIjoiZDFlM2Y3ZDUwOWYxNDhmYmI0NGMyOWIxYTZmYTkyMzMiLCJwIjoiaiJ9)

## This PR
Attempts to fix said issue and update tests to enforce correct behavior.
