### PR TITLE
Configure JSON printer to include null fields in HLES/CSLB pipelines

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
@@ -18,6 +18,11 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
     */
   implicit val logger: Logger = LoggerFactory.getLogger(getClass)
 
+  // we save space by nixing whitespace, but we include null values to ensure that
+  // we don't accidentally drop fields, regardless of whether any of them have been
+  // filled in in our input data
+  val printer: Printer = Printer.noSpaces.copy(dropNullValues = false)
+
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     val rawRecords = readRecords(ctx, args)
 
@@ -27,7 +32,8 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
     StorageIO.writeJsonLists(
       cslbTransformations,
       "CSLB data",
-      s"${args.outputPrefix}/cslb"
+      s"${args.outputPrefix}/cslb",
+      printer = printer
     )
     ()
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.monster.dap.cslb
 
+import io.circe.Printer
 import com.spotify.scio.ScioContext
 import com.spotify.scio.values.SCollection
 import org.broadinstitute.monster.common.{PipelineBuilder, StorageIO}
@@ -21,7 +22,7 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
   // we save space by nixing whitespace, but we include null values to ensure that
   // we don't accidentally drop fields, regardless of whether any of them have been
   // filled in in our input data
-  val printer: Printer = Printer.noSpaces.copy(dropNullValues = false)
+  val jsonPrinter: Printer = Printer.noSpaces.copy(dropNullValues = false)
 
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     val rawRecords = readRecords(ctx, args)
@@ -33,7 +34,7 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
       cslbTransformations,
       "CSLB data",
       s"${args.outputPrefix}/cslb",
-      printer = printer
+      printer = jsonPrinter
     )
     ()
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentTransformationPipelineBuilder.scala
@@ -25,6 +25,10 @@ object EnvironmentTransformationPipelineBuilder extends PipelineBuilder[Args] {
     val environment =
       rawEnvRecords.transform("Map Environment")(_.map(EnvironmentTransformations.mapEnvironment))
 
+    // unlike our other pipelines, we don't configure our printer to include
+    // null-valued fields in our environment data output, because environment data is
+    // much, much larger than our other tables and the size increase from including null fields
+    // might significantly impact pipeline execution time
     StorageIO.writeJsonLists(
       environment,
       "Environmental data",

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationPipelineBuilder.scala
@@ -39,7 +39,12 @@ object HLESurveyTransformationPipelineBuilder extends PipelineBuilder[Args] {
     )
 
     StorageIO.writeJsonLists(dogs, "Dogs", s"${args.outputPrefix}/hles_dog", printer = jsonPrinter)
-    StorageIO.writeJsonLists(owners, "Owners", s"${args.outputPrefix}/hles_owner", printer = jsonPrinter)
+    StorageIO.writeJsonLists(
+      owners,
+      "Owners",
+      s"${args.outputPrefix}/hles_owner",
+      printer = jsonPrinter
+    )
     StorageIO.writeJsonLists(
       cancerConditions,
       "Cancer conditions",

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationPipelineBuilder.scala
@@ -23,7 +23,7 @@ object HLESurveyTransformationPipelineBuilder extends PipelineBuilder[Args] {
   // we save space by nixing whitespace, but we include null values to ensure that
   // we don't accidentally drop fields, regardless of whether any of them have been
   // filled in in our input data
-  val printer: Printer = Printer.noSpaces.copy(dropNullValues = false)
+  val jsonPrinter: Printer = Printer.noSpaces.copy(dropNullValues = false)
 
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     val rawRecords = readRecords(ctx, args)
@@ -38,19 +38,19 @@ object HLESurveyTransformationPipelineBuilder extends PipelineBuilder[Args] {
       _.flatMap(HealthTransformations.mapHealthConditions)
     )
 
-    StorageIO.writeJsonLists(dogs, "Dogs", s"${args.outputPrefix}/hles_dog", printer = printer)
-    StorageIO.writeJsonLists(owners, "Owners", s"${args.outputPrefix}/hles_owner", printer = printer)
+    StorageIO.writeJsonLists(dogs, "Dogs", s"${args.outputPrefix}/hles_dog", printer = jsonPrinter)
+    StorageIO.writeJsonLists(owners, "Owners", s"${args.outputPrefix}/hles_owner", printer = jsonPrinter)
     StorageIO.writeJsonLists(
       cancerConditions,
       "Cancer conditions",
       s"${args.outputPrefix}/hles_cancer_condition",
-      printer = printer
+      printer = jsonPrinter
     )
     StorageIO.writeJsonLists(
       healthConditions,
       "Health conditions",
       s"${args.outputPrefix}/hles_health_condition",
-      printer = printer
+      printer = jsonPrinter
     )
     ()
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.9")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1661)

We were losing a field in the HLES output because none of the dog records in the survey included a value for it. This change causes the JSON printer to still include null values, so no fields will be dropped under any circumstances. This should only affect the size of the JSON - TSV size will be unaffected other than the addition of this errantly omitted column.

I've left a comment explaining why this change is not being applied to the environment pipeline.

This change depends on the merging and release of https://github.com/DataBiosphere/ingest-utils/pull/19 (and the compilation for this PR will fail until that happens)