### PR TITLE
Primary Dog Activity Level

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformations.scala
@@ -264,7 +264,9 @@ object DemographicsTransformations {
 
     def activityLevel(activity: String): Option[Long] =
       if (allActivities.contains[Long](ActivityValues(activity))) {
-        rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(Some(3L))
+        // If dd_activities contains one activity, that should be the primary
+        if (allActivities.length.equals(1)) Some(1L)
+        else { rawRecord.getOptionalNumber(s"dd_${activity}_m").orElse(Some(3L)) }
       } else {
         None
       }

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/dog/DemographicsTransformationsSpec.scala
@@ -497,6 +497,9 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
       "dd_service_medical_other_1" -> Array("Medical!"),
       "dd_service_other_1" -> Array("Activity!")
     )
+    val companionDog = Map[String, Array[String]](
+      "dd_activities" -> Array("1")
+    )
 
     val serviceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, serviceDog),
@@ -504,6 +507,10 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     )
     val assistanceOut = DemographicsTransformations.mapActivities(
       RawRecord(1, assistanceDog),
+      HlesDogDemographics.init()
+    )
+    val companionOut = DemographicsTransformations.mapActivities(
+      RawRecord(1, companionDog),
       HlesDogDemographics.init()
     )
 
@@ -535,5 +542,6 @@ class DemographicsTransformationsSpec extends AnyFlatSpec with Matchers with Opt
     assistanceOut.ddActivitiesServiceOtherMedicalDescription.value shouldBe "Medical!"
     assistanceOut.ddActivitiesServiceOtherDescription.value shouldBe "Activity!"
 
+    companionOut.ddActivitiesCompanionAnimal.value shouldBe 1L
   }
 }

--- a/hack/validation/test_release.py
+++ b/hack/validation/test_release.py
@@ -142,5 +142,10 @@ class ReleaseValidationTestCase(unittest.TestCase):
         self.assertIn('hs_eye_condition_cause', affected_eye_condition_row)
         self.assertEqual(affected_eye_condition_row['hs_eye_condition_cause'], '99')
 
+    def test_single_activity_dog(self):
+        affected_single_activity_row = self.find_affected_row(self._hles_dog_data, '90766')
+        self.assertIn('dd_activities_companion_animal', affected_single_activity_row)
+        self.assertEqual(affected_single_activity_row['dd_activities_companion_animal'], '1')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Why
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1691)
Participants who only chose one Activity in the initial question ("dd_activities") are not shown the follow-up question ("_m") to choose which activities is primary and secondary. We should be defaulting these to "Primary" (1) as their activity level.

## This PR

- Updated DemographicsTransformation code to check if only one activity was listed and defaulting an activity level of 1.
- Updated unit tests.
