### PR TITLE
Upgrade ingest-utils

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.11")


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1737)
We need to be up to date with upstream dependencies like Beam and Scio.

## This PR
* Upgrades the ingest-utils version to 2.1.11