### PR TITLE
[DSPDC-1771] Add explicit inter-solid dependencies

### DIFF
--- a/orchestration/dap_orchestration/pipelines.py
+++ b/orchestration/dap_orchestration/pipelines.py
@@ -1,4 +1,4 @@
-from dagster import pipeline, ModeDefinition
+from dagster import pipeline, ModeDefinition, ResourceDefinition
 
 from dagster_utils.resources.beam.local_beam_runner import local_beam_runner
 from dagster_utils.resources.beam.dataflow_beam_runner import dataflow_beam_runner
@@ -36,9 +36,18 @@ prod_mode = ModeDefinition(
     }
 )
 
+test_mode = ModeDefinition(
+    name="test",
+    resource_defs={
+        "beam_runner": ResourceDefinition.mock_resource(),
+        "refresh_directory": refresh_directory,
+        "outfiles_writer": ResourceDefinition.mock_resource()
+    }
+)
+
 
 @pipeline(
-    mode_defs=[local_mode, dev_mode, prod_mode]
+    mode_defs=[local_mode, dev_mode, prod_mode, test_mode]
 )
 def refresh_data_all() -> None:
     collected_outputs = [

--- a/orchestration/dap_orchestration/pipelines.py
+++ b/orchestration/dap_orchestration/pipelines.py
@@ -41,14 +41,9 @@ prod_mode = ModeDefinition(
     mode_defs=[local_mode, dev_mode, prod_mode]
 )
 def refresh_data_all() -> None:
-    hles_extract_records()
-    hles_transform_records()
-
-    cslb_extract_records()
-    cslb_transform_records()
-
-    env_extract_records()
-    env_transform_records()
-
-    # the transform output should be in the same directory for all 3 pipelines
-    write_outfiles()
+    collected_outputs = [
+        hles_transform_records(hles_extract_records()),
+        cslb_transform_records(cslb_extract_records()),
+        env_transform_records(env_extract_records())
+    ]
+    write_outfiles(collected_outputs)

--- a/orchestration/dap_orchestration/solids.py
+++ b/orchestration/dap_orchestration/solids.py
@@ -1,4 +1,4 @@
-from dagster import Bool, String, solid, configured
+from dagster import Bool, String, solid, configured, InputDefinition, Nothing
 from dagster.core.execution.context.compute import AbstractComputeExecutionContext
 
 extract_project = "dog-aging-hles-extraction"
@@ -82,7 +82,8 @@ def env_extract_records(config: dict[str, str]) -> dict[str, str]:
         "output_prefix": String,
         "target_class": String,
         "scala_project": String
-    }
+    },
+    input_defs=[InputDefinition("start", Nothing)]
 )
 def transform_records(context: AbstractComputeExecutionContext) -> None:
     """
@@ -144,10 +145,13 @@ def env_transform_records(config: dict[str, str]) -> dict[str, str]:
         "working_dir": String,
     }
 )
-def write_outfiles(context: AbstractComputeExecutionContext) -> None:
+def write_outfiles(context: AbstractComputeExecutionContext, fan_in_results: list[object]) -> None:
     """
     This solid will take in the arguments provided in context and call the convert-output-to-tsv script
     on the transform outputs. The script is currently expecting transform outputs from all 3 pipelines and will
     error if one of them is not found at the input directory.
+
+    NOTE: The fan_in_results param allows to introduce a fan-in dependency from upstream transformation
+    solids, but is ignored by this solid.
     """
     context.resources.outfiles_writer.run(context.solid_config["working_dir"], context.resources.refresh_directory)

--- a/orchestration/dap_orchestration/solids.py
+++ b/orchestration/dap_orchestration/solids.py
@@ -45,7 +45,14 @@ def _build_extract_config(config: dict[str, str], output_prefix: str,
     }
 
 
-@configured(extract_records)
+@configured(
+    extract_records,
+    config_schema={
+        "pull_data_dictionaries": Bool,
+        "end_time": String,
+        "api_token": String,
+    }
+)
 def hles_extract_records(config: dict[str, str]) -> dict[str, str]:
     return _build_extract_config(
         config=config,
@@ -55,7 +62,14 @@ def hles_extract_records(config: dict[str, str]) -> dict[str, str]:
     )
 
 
-@configured(extract_records)
+@configured(
+    extract_records,
+    config_schema={
+        "pull_data_dictionaries": Bool,
+        "end_time": String,
+        "api_token": String,
+    }
+)
 def cslb_extract_records(config: dict[str, str]) -> dict[str, str]:
     return _build_extract_config(
         config=config,
@@ -65,7 +79,14 @@ def cslb_extract_records(config: dict[str, str]) -> dict[str, str]:
     )
 
 
-@configured(extract_records)
+@configured(
+    extract_records,
+    config_schema={
+        "pull_data_dictionaries": Bool,
+        "end_time": String,
+        "api_token": String,
+    }
+)
 def env_extract_records(config: dict[str, str]) -> dict[str, str]:
     return _build_extract_config(
         config=config,

--- a/orchestration/dap_orchestration/tests/test_pipelines.py
+++ b/orchestration/dap_orchestration/tests/test_pipelines.py
@@ -1,140 +1,50 @@
-import unittest
+from dagster import execute_pipeline
+import pytest
 
-import dap_orchestration
-from dagster import ModeDefinition, execute_solid, SolidExecutionResult
-
-import dap_orchestration.resources
-import dap_orchestration.solids
-
-from dagster_utils.resources.beam.noop_beam_runner import noop_beam_runner
+from dap_orchestration.pipelines import refresh_data_all
 
 
-class PipelineTestCase(unittest.TestCase):
-    def setUp(self):
-        self.base_solid_config: dict[str, object] = {
-            "resources": {
-                "beam_runner": {
-                    "config": {
-                        "working_dir": "/example/local_beam_runner/bar",
+@pytest.fixture
+def run_config():
+    return {
+        'resources': {
+            'refresh_directory': {
+                'config': {
+                    'refresh_directory': 'fake_dir'}
+            }
+        },
+        'solids': {
+            'cslb_extract_records': {
+                'config':
+                    {
+                        'api_token': 'fake_token',
+                        'end_time': 'fake_time',
+                        'pull_data_dictionaries': True
                     }
-                },
-                "refresh_directory": {
-                    "config": {
-                        "refresh_dir": "/example/local_beam_runner/bar",
-                    }
+            },
+            'env_extract_records': {
+                'config': {
+                    'api_token': 'fake_token',
+                    'end_time': 'fake_time',
+                    'pull_data_dictionaries': True
+                }
+            },
+            'hles_extract_records': {
+                'config': {
+                    'api_token': 'fake_token',
+                    'end_time': 'fake_time',
+                    'pull_data_dictionaries': True
+                }
+            },
+            'write_outfiles': {
+                'config': {
+                    'working_dir': 'fake_dir'
                 }
             }
         }
-        self.extract_config = {
-            "pull_data_dictionaries": False,
-            "end_time": "2020-05-19T23:59:59-05:00",
-            "api_token": "ddddd",
-        }
-        self.outfiles_config = {
-            "working_dir": "/example/local_beam_runner/bar",
-        }
-        self.mode = ModeDefinition(
-            resource_defs={
-                "beam_runner": noop_beam_runner,
-                "refresh_directory": dap_orchestration.resources.test_refresh_directory,
-                "outfiles_writer": dap_orchestration.resources.test_outfiles_writer
-            }
-        )
+    }
 
-    def test_hles_extract(self):
-        hles_extract_config = {
-            "solids": {
-                "hles_extract_records": {
-                    "config": self.extract_config
-                }
-            }
-        }
-        dataflow_config = {**self.base_solid_config, **hles_extract_config}
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.hles_extract_records,
-            mode_def=self.mode,
-            run_config=dataflow_config
-        )
 
-        self.assertTrue(result.success)
-
-    def test_cslb_extract(self):
-        cslb_extract_config = {
-            "solids": {
-                "cslb_extract_records": {
-                    "config": self.extract_config
-                }
-            }
-        }
-        dataflow_config = {**self.base_solid_config, **cslb_extract_config}
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.cslb_extract_records,
-            mode_def=self.mode,
-            run_config=dataflow_config
-        )
-
-        self.assertTrue(result.success)
-
-    def test_environment_extract(self):
-        env_extract_config = {
-            "solids": {
-                "env_extract_records": {
-                    "config": self.extract_config
-                }
-            }
-        }
-        dataflow_config = {**self.base_solid_config, **env_extract_config}
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.env_extract_records,
-            mode_def=self.mode,
-            run_config=dataflow_config
-        )
-
-        self.assertTrue(result.success)
-
-    def test_hles_transform(self):
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.hles_transform_records,
-            mode_def=self.mode,
-            run_config=self.base_solid_config
-        )
-
-        self.assertTrue(result.success)
-
-    def test_cslb_transform(self):
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.cslb_transform_records,
-            mode_def=self.mode,
-            run_config=self.base_solid_config
-        )
-
-        self.assertTrue(result.success)
-
-    def test_env_transform(self):
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.env_transform_records,
-            mode_def=self.mode,
-            run_config=self.base_solid_config
-        )
-
-        self.assertTrue(result.success)
-
-    def test_write_outfiles(self):
-        write_outfiles_config = {
-            "solids": {
-                "write_outfiles": {
-                    "config": {
-                        "working_dir": "/example/local_beam_runner/bar",
-                    }
-                }
-            }
-        }
-        dataflow_config = {**self.base_solid_config, **write_outfiles_config}
-        result: SolidExecutionResult = execute_solid(
-            dap_orchestration.solids.write_outfiles,
-            mode_def=self.mode,
-            run_config=dataflow_config,
-            input_values={"fan_in_results": []}
-        )
-
-        self.assertTrue(result.success)
+def test_pipeline(run_config):
+    result = execute_pipeline(refresh_data_all, mode="test", run_config=run_config)
+    assert result.success, "Pipeline run should be successful"

--- a/orchestration/dap_orchestration/tests/test_pipelines.py
+++ b/orchestration/dap_orchestration/tests/test_pipelines.py
@@ -133,7 +133,8 @@ class PipelineTestCase(unittest.TestCase):
         result: SolidExecutionResult = execute_solid(
             dap_orchestration.solids.write_outfiles,
             mode_def=self.mode,
-            run_config=dataflow_config
+            run_config=dataflow_config,
+            input_values={"fan_in_results": []}
         )
 
         self.assertTrue(result.success)

--- a/orchestration/dap_orchestration/tests/test_solids.py
+++ b/orchestration/dap_orchestration/tests/test_solids.py
@@ -1,0 +1,157 @@
+import pytest
+from dagster import ModeDefinition, execute_solid, SolidExecutionResult
+from dagster_utils.resources.beam.noop_beam_runner import noop_beam_runner
+
+import dap_orchestration
+import dap_orchestration.resources
+import dap_orchestration.solids
+
+
+@pytest.fixture
+def base_solid_config():
+    return {
+        "resources": {
+            "beam_runner": {
+                "config": {
+                    "working_dir": "/example/local_beam_runner/bar",
+                }
+            },
+            "refresh_directory": {
+                "config": {
+                    "refresh_dir": "/example/local_beam_runner/bar",
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def extract_config():
+    return {
+        "pull_data_dictionaries": False,
+        "end_time": "2020-05-19T23:59:59-05:00",
+        "api_token": "ddddd",
+    }
+
+
+@pytest.fixture
+def outfiles_config():
+    return {
+        "working_dir": "/example/local_beam_runner/bar",
+    }
+
+
+@pytest.fixture
+def mode():
+    return ModeDefinition(
+        resource_defs={
+            "beam_runner": noop_beam_runner,
+            "refresh_directory": dap_orchestration.resources.test_refresh_directory,
+            "outfiles_writer": dap_orchestration.resources.test_outfiles_writer
+        }
+    )
+
+
+def test_hles_extract(extract_config, base_solid_config, mode):
+    hles_extract_config = {
+        "solids": {
+            "hles_extract_records": {
+                "config": extract_config
+            }
+        }
+    }
+    dataflow_config = {**base_solid_config, **hles_extract_config}
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.hles_extract_records,
+        mode_def=mode,
+        run_config=dataflow_config
+    )
+
+    assert result.success
+
+
+def test_cslb_extract(extract_config, base_solid_config, mode):
+    cslb_extract_config = {
+        "solids": {
+            "cslb_extract_records": {
+                "config": extract_config
+            }
+        }
+    }
+    dataflow_config = {**base_solid_config, **cslb_extract_config}
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.cslb_extract_records,
+        mode_def=mode,
+        run_config=dataflow_config
+    )
+
+    assert result.success
+
+
+def test_env_extract(extract_config, base_solid_config, mode):
+    env_extract_config = {
+        "solids": {
+            "env_extract_records": {
+                "config": extract_config
+            }
+        }
+    }
+    dataflow_config = {**base_solid_config, **env_extract_config}
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.env_extract_records,
+        mode_def=mode,
+        run_config=dataflow_config
+    )
+
+    assert result.success
+
+
+def test_hles_transform(base_solid_config, mode):
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.hles_transform_records,
+        mode_def=mode,
+        run_config=base_solid_config
+    )
+
+    assert result.success
+
+
+def test_cslb_transform(base_solid_config, mode):
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.cslb_transform_records,
+        mode_def=mode,
+        run_config=base_solid_config
+    )
+
+    assert result.success
+
+
+def test_env_transform(base_solid_config, mode):
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.env_transform_records,
+        mode_def=mode,
+        run_config=base_solid_config
+    )
+
+    assert result.success
+
+
+def test_write_outfiles(base_solid_config, mode):
+    write_outfiles_config = {
+        "solids": {
+            "write_outfiles": {
+                "config": {
+                    "working_dir": "/example/local_beam_runner/bar",
+                }
+            }
+        }
+    }
+    dataflow_config = {**base_solid_config, **write_outfiles_config}
+    result: SolidExecutionResult = execute_solid(
+        dap_orchestration.solids.write_outfiles,
+        mode_def=mode,
+        run_config=dataflow_config,
+        input_values={"fan_in_results": []}
+    )
+
+    assert result.success


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1771)
As part of my spiking for the TDR ticket, I discovered we had no explicit dependencies between solids in our refresh pipeline definition. This means that solids can effectively execute in any order and potentially in parallel. We have not bumped into this in practice because dagster runs the solids in the order in which they're declared and serially, when run locally.

## This PR
* Introduces explicit solid dependencies between the extract + transform pairs, and a final "fan-in" to the `write_outfiles` solid. The fan-in consumes a list of results that gets dropped on the floor, but is necessary for the dependency to get created.
* Adds a test case that runs the pipeline using mock resources. I have found this sort of test useful to verify the overall pipeline definition, especially when there are complex fan-ins/outs.
* Shifts our tests to be pure pytest
* Adds `api_token`, `pull_data_dictionaries`, and `end_time` as explicit config schema entries for the extract solids. I am not sure how this ever worked, but I was unable to run the pipeline without these schema items defined.