### PR TITLE
Create EOLS extraction pipeline

### DIFF
--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/eols/EolsExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/eols/EolsExtractionPipeline.scala
@@ -1,0 +1,58 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
+import org.broadinstitute.monster.dap.common.{
+  Args,
+  ExtractionPipelineBuilder,
+  FilterDirective,
+  FilterOps,
+  HttpWrapper,
+  OkWrapper,
+  RedCapClient
+}
+
+// Ignore IntelliJ, this is used to make the implicit parser compile.
+import Args._
+import java.time.{OffsetDateTime, ZoneOffset}
+
+object EolsExtractionPipeline extends ScioApp[Args] {
+  // january 1, 2018 - we ignore any records before this by default (though there shouldn't be any)
+  val EOLSEpoch = OffsetDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-5))
+
+  val forms = List(
+    "end_of_life"
+  )
+
+  def extractionFiltersGenerator(args: Args): List[FilterDirective] =
+    args.startTime
+      .map(start =>
+        List(
+          FilterDirective("eol_date_dog_died", FilterOps.>, RedCapClient.redcapFormatDate(start))
+        )
+      )
+      .getOrElse(List()) ++
+      args.endTime
+        .map(end =>
+          List(
+            FilterDirective("eol_date_dog_died", FilterOps.<, RedCapClient.redcapFormatDate(end))
+          )
+        )
+        .getOrElse(List())
+
+  val subdir = "eols";
+  val arm = "baseline_arm_1"
+  val fieldList = List("eol_willing_to_complete", "eol_date_dog_died")
+
+  def buildPipelineWithWrapper(wrapper: HttpWrapper): PipelineBuilder[Args] =
+    new ExtractionPipelineBuilder(
+      forms,
+      extractionFiltersGenerator,
+      (_, _) => List(arm),
+      fieldList,
+      subdir,
+      100,
+      RedCapClient.apply(_: List[String], wrapper)
+    )
+
+  override def pipelineBuilder: PipelineBuilder[Args] = buildPipelineWithWrapper(new OkWrapper())
+}

--- a/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/eols/EolsExtractionPipelineBuilderIntegrationSpec.scala
+++ b/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/eols/EolsExtractionPipelineBuilderIntegrationSpec.scala
@@ -1,0 +1,79 @@
+package org.broadinstitute.monster.dap.eols
+
+import better.files.File
+import org.broadinstitute.monster.common.PipelineBuilderSpec
+import org.broadinstitute.monster.dap.common
+import org.broadinstitute.monster.dap.common.{
+  Args,
+  GetRecords,
+  MockOkWrapper,
+  RedcapMsgGenerator,
+  RedcapRequestGeneratorParams
+}
+
+import java.time.{LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
+
+class EolsExtractionPipelineBuilderIntegrationSpec extends PipelineBuilderSpec[Args] {
+  val outputDir = File.newTemporaryDirectory()
+  val eolsOutputDir = File(outputDir, EolsExtractionPipeline.subdir)
+  override def afterAll(): Unit = outputDir.delete()
+
+  val start =
+    OffsetDateTime.of(LocalDate.of(2020, 11, 15), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+
+  val end =
+    OffsetDateTime.of(LocalDate.of(2020, 11, 16), LocalTime.MIDNIGHT, ZoneOffset.UTC)
+
+  override val testArgs =
+    Args(
+      "token-foken-lo-token",
+      Some(start),
+      Some(end),
+      outputDir.pathAsString,
+      pullDataDictionaries = false
+    )
+
+  val expectedStudyIds = List("some_study_id", "some_other_id")
+
+  val studyIdsRequest = RedcapRequestGeneratorParams(
+    testArgs.apiToken,
+    List(EolsExtractionPipeline.arm),
+    GetRecords(
+      fields = List("study_id"),
+      filters = EolsExtractionPipeline.extractionFiltersGenerator(testArgs)
+    )
+  )
+
+  val followUpRecords = common.RedcapRequestGeneratorParams(
+    testArgs.apiToken,
+    List(EolsExtractionPipeline.arm),
+    GetRecords(
+      ids = expectedStudyIds,
+      fields = EolsExtractionPipeline.fieldList,
+      forms = EolsExtractionPipeline.forms
+    )
+  )
+
+  val mockWrapper = new MockOkWrapper(
+    Map(
+      studyIdsRequest -> RedcapMsgGenerator.toRedcapFormat(expectedStudyIds.map { i =>
+        Map(
+          "study_id" -> i.toString
+        )
+      }),
+      followUpRecords -> RedcapMsgGenerator.toRedcapFormat(expectedStudyIds.map { _ =>
+        Map(
+          "eol_willing_to_complete" -> "1"
+        )
+      })
+    )
+  )
+
+  override val builder = EolsExtractionPipeline.buildPipelineWithWrapper(mockWrapper)
+
+  behavior of "EOLSExtractionPipelineBuilder"
+
+  it should "successfully download records from RedCap" in {
+    readMsgs(eolsOutputDir, "records/*.json") shouldNot be(empty)
+  }
+}


### PR DESCRIPTION
## Why
We need to add the extraction pipeline for DAP EOLS data
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1799)

## This PR
Creates the EOLS extraction pipeline and test.
Using baseline_arm_1 for arm and
filtering based off "eol_willing_to_complete", "eol_date_dog_died"

## Checklist
- [x] Documentation has been updated as needed.
