### PR TITLE
Group CSLB records by record, redcap_event_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ where _canine_social_and_learned_behavior_complete_ is marked as complete.
 #### CSLB Schema Design
 * A single `cslb` table which contains a single CSLB record per dog per year. 
 * The table includes the 16 CSLB question responses and a foreign key to the dog table. 
+* Rows in the final Cslb table will be unique on _dog_id_ and _cslb_date_.
 
 
 ## Environmental Data

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
@@ -41,7 +41,7 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
         s"${args.inputPrefix}/records/*.json"
       )
 
-    // Group by study ID (record number) and arm (address_year_month)
+    // Group by study ID (record) and arm (redcap_event_name)
     // to get the format: (studyId, arm_id, Iterable((fieldName, Iterable(value))))
     rawRecords
       .groupBy(record => {

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformationPipelineBuilder.scala
@@ -41,12 +41,12 @@ object CslbTransformationPipelineBuilder extends PipelineBuilder[Args] {
         s"${args.inputPrefix}/records/*.json"
       )
 
-    // Group by study ID (record number) and field name
-    // to get the format: (studyId, Iterable((fieldName, Iterable(value))))
+    // Group by study ID (record number) and arm (address_year_month)
+    // to get the format: (studyId, arm_id, Iterable((fieldName, Iterable(value))))
     rawRecords
       .groupBy(record => {
         (record.read[String]("record"), record.read[String]("redcap_event_name"))
-      }) // <-- record, redcap_event_name
+      })
       .map {
         case ((id, eventName), rawRecordValues) =>
           val fields = rawRecordValues

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbTransformations.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap.cslb
 
 import org.broadinstitute.monster.dap.common.RawRecord
 import org.broadinstitute.monster.dogaging.jadeschema.table.Cslb
+import com.spotify.scio.ScioMetrics.counter
 
 object CslbTransformations {
 
@@ -29,7 +30,9 @@ object CslbTransformations {
             cslbOtherChanges = rawRecord.getOptionalStripped("cslb_other_changes")
           )
         )
-      case _ =>
+      case _ => {
+        counter("cslb", "missing_cslb_date").inc()
         None
+      }
     }
 }


### PR DESCRIPTION
## Why

The Cslb transformation pipeline is currently erroring out to due to multiple instances of the same field present in a single raw record for a dog because we were grouping multiple arms worth of data together. Grouping by record and redcap_event_name ensures there is one record per dog per arm.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1811)

## This PR
Modified the CSLB Transformation Pipeline Builder to group records by record and redcap_event_name
Added an error counter for records missing cslb_date
Updated comments + readme

## Checklist
- [X] Documentation has been updated as needed.
