### PR TITLE
Update sample table primary key and update column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ sample_id as well as some other metadata about the sample.
 
 #### Sample Schema Design
 * A single `sample` table which contains multiple samples per dog.
-* Simple lookup table with 6 fields and a foreign key to the dog table.
-* Rows in the final Environment table will be unique on _dog_id_ and _sample_id_.
+* Simple lookup table with 5 fields including a foreign key to the dog table.
+* Rows in the final Environment table will be unique on _sample_id_.
 
 
 ## Label Mapping Table

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
@@ -12,9 +12,9 @@ object SampleTransformations {
           Sample(
             dogId = rawRecord.getRequired("study_id").toLong,
             cohort = rawRecord.getRequired("ce_enroll_stat").toLong,
-            sampleId = Some(rawRecord.getRequired("k1_tube_serial").toLong),
+            sampleId = rawRecord.getRequired("k1_tube_serial").toLong,
             sampleType = "saliva_DNA_lowcov",
-            dateCollected = dateCollected
+            dateSwabArrivalLaboratory = dateCollected
           )
         )
       case _ =>

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/sample/SampleTransformationSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/sample/SampleTransformationSpec.scala
@@ -38,8 +38,18 @@ class SampleTransformationSpec extends AnyFlatSpec {
     val output = SampleTransformations.mapSampleData(exampleSampleRecord).get
     output.dogId shouldBe 12345L
     output.cohort shouldBe 9L
-    output.sampleId shouldBe Some(54321L)
+    output.sampleId shouldBe 54321L
     output.sampleType shouldBe "saliva_DNA_lowcov"
-    output.dateCollected shouldBe LocalDate.parse("2021-05-20 00:00:00", DAPDateTimeFormatter)
+    output.dateSwabArrivalLaboratory shouldBe LocalDate.parse(
+      "2021-05-20 00:00:00",
+      DAPDateTimeFormatter
+    )
+  }
+
+  it should "raise when serial number is not provided" in {
+    val invalidSerialRecord = RawRecord(id = 1, exampleSampleFields.-("k1_tube_serial"))
+    assertThrows[IllegalStateException] {
+      SampleTransformations.mapSampleData(invalidSerialRecord)
+    }
   }
 }

--- a/hack/convert-output-to-tsv.py
+++ b/hack/convert-output-to-tsv.py
@@ -49,12 +49,13 @@ class PrimaryKeyGenerator:
     # this will calculate pk_name during init
     def __post_init__(self):
         # most tables should have "dog_id" as a key
-        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb",
-                               "sample"}:
+        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb"}:
             self.pk_name = 'dog_id'
         # owner table is linked to hles_dog via "owner_id"
         elif self.table_name == 'hles_owner':
             self.pk_name = 'owner_id'
+        elif self.table_name == 'sample':
+            self.pk_name = 'sample_id'
         else:
             raise ValueError(f"Unrecognized table: {self.table_name}")
 

--- a/schema/src/main/jade-tables/sample.table.json
+++ b/schema/src/main/jade-tables/sample.table.json
@@ -2,9 +2,20 @@
   "name": "sample",
   "columns": [
     {
-      "name": "dog_id",
+      "name": "sample_id",
       "datatype": "integer",
       "type": "primary_key"
+    },
+    {
+      "name": "dog_id",
+      "datatype": "integer",
+      "type": "required",
+      "links": [
+        {
+          "table_name": "hles_dog",
+          "column_name": "dog_id"
+        }
+      ]
     },
     {
       "name": "cohort",
@@ -17,11 +28,7 @@
       "type": "required"
     },
     {
-      "name": "sample_id",
-      "datatype": "integer"
-    },
-    {
-      "name": "date_collected",
+      "name": "date_swab_arrival_laboratory",
       "datatype": "date",
       "type": "required"
     }


### PR DESCRIPTION
## Why
**sample_id** should be the primary key for the sample table while dog_id serves as a link to hles_dog.
The same dog_id can have multiple sample_ids in the samples table. DAP also requested a column name change.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1812)

## This PR

- Updated name for date_collected field to date_swab_arrival_laboratory
- Made sample_id the primary key for the sample table schema instead of dog_id
- Updated dog_id to be a required field and added a link to hles_dog
- Updated the transformation code to reflect that sampe_id is now a required field
- Added a unit test for missing sample_id
- Updated the primary key for the sample table in the tsv generator script
- Updated readme

## Checklist
- [x] Documentation has been updated as needed.
