### PR TITLE
Extend EOLS transformations code to process recent_aging_characteristics fields

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -36,7 +36,8 @@ object EolsTransformations {
           eolAddVemr = rawRecord.getOptionalBoolean("eol_add_med_record_yn"),
           // todo: add transformation logic for additional fragments
           eolsNewCondition = None,
-          eolsRecentAgingChar = None,
+          eolsRecentAgingChar =
+            Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
           eolsRecentSymptom = None,
           eolsDeath = None,
           eolsEuthan = None,

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -34,14 +34,12 @@ object EolsTransformations {
           eolOldAgeSecondaryOtherDescription = rawRecord.getOptional("eol_old_age_cod_2_specify"),
           eolNotesDescription = rawRecord.getOptional("eol_notes"),
           eolAddVemr = rawRecord.getOptionalBoolean("eol_add_med_record_yn"),
-          // todo: add transformation logic for additional fragments
-          eolsNewCondition = None,
-          eolsRecentAgingChar =
-            Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
-          eolsRecentSymptom = None,
-          eolsDeath = None,
-          eolsEuthan = None,
-          eolsIllness = None
+          // todo: add eolsNewCondition
+          eolsRecentAgingChar = Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord))
+          // todo: add eolsRecentSymptom
+          // todo: add eolsDeath
+          // todo: add eolsEuthan
+          // todo: add eolsIllness
         )
       )
     } else {

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
@@ -6,8 +6,8 @@ import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsRecentAgingCh
 object RecentAgingCharsTransformations {
 
   /**
-    * Parse all geocoding_metadata variables out of a raw RedCap record,
-    * injecting them into a partially-modeled environment record.
+    * Parse all eol_aging_characteristics data out of a raw RedCap record,
+    * injecting them into a partially-modeled Eols record.
     */
   def mapRecentAgingChars(rawRecord: RawRecord): EolsRecentAgingChar = {
     val agingChars = Some(rawRecord.getArray("eol_aging_characteristics").map(_.toLong))

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsRecentAgingChar
+
+object RecentAgingCharsTransformations {
+
+  /**
+    * Parse all geocoding_metadata variables out of a raw RedCap record,
+    * injecting them into a partially-modeled environment record.
+    */
+  def mapRecentAgingChars(rawRecord: RawRecord): EolsRecentAgingChar = {
+    val agingChars = Some(rawRecord.getArray("eol_aging_characteristics").map(_.toLong))
+    val otherChar = agingChars.map(_.contains(98L))
+    EolsRecentAgingChar(
+      eolRecentAgingCharNone = agingChars.map(_.contains(0L)),
+      eolRecentAgingCharBlind = agingChars.map(_.contains(1L)),
+      eolRecentAgingCharDeaf = agingChars.map(_.contains(2L)),
+      eolRecentAgingCharWeightloss = agingChars.map(_.contains(3L)),
+      eolRecentAgingCharMobilityWeak = agingChars.map(_.contains(4L)),
+      eolRecentAgingCharMobilityPain = agingChars.map(_.contains(5L)),
+      eolRecentAgingCharOtherPain = agingChars.map(_.contains(6L)),
+      eolRecentAgingCharCleanliness = agingChars.map(_.contains(7L)),
+      eolRecentAgingCharConfusion = agingChars.map(_.contains(8L)),
+      eolRecentAgingCharInteractionChange = agingChars.map(_.contains(9L)),
+      eolRecentAgingCharSleep = agingChars.map(_.contains(10L)),
+      eolRecentAgingCharHousesoiling = agingChars.map(_.contains(11L)),
+      eolRecentAgingCharAnxiety = agingChars.map(_.contains(12L)),
+      eolRecentAgingCharEatDrink = agingChars.map(_.contains(13L)),
+      eolRecentAgingCharInactivity = agingChars.map(_.contains(14L)),
+      eolRecentAgingCharRepetitiveActivity = agingChars.map(_.contains(15L)),
+      eolRecentAgingCharMemory = agingChars.map(_.contains(16L)),
+      eolRecentAgingCharRecognition = agingChars.map(_.contains(17L)),
+      eolRecentAgingCharSundowning = agingChars.map(_.contains(18L)),
+      eolRecentAgingCharOther = otherChar,
+      eolRecentAgingCharOtherDescription =
+        if (otherChar.contains(true))
+          rawRecord.getOptional("eol_aging_characteristics_specify")
+        else None
+    )
+  }
+}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformationsSpec.scala
@@ -1,0 +1,31 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dap.eols.RecentAgingCharsTransformations
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RecentAgingCharsTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  behavior of "RecentAgingCharsTransformations"
+
+  it should "map recent aging characteristics where available" in {
+    val recentAgingChars = Map(
+      "eol_aging_characteristics" -> Array("2", "3", "17", "98"),
+      "eol_aging_characteristics_specify" -> Array("Other description")
+    )
+
+    val recentAgingCharsMapped = RecentAgingCharsTransformations.mapRecentAgingChars(
+      RawRecord(1, recentAgingChars)
+    )
+
+    // output of the example record's recent aging characteristics transformations
+    recentAgingCharsMapped.eolRecentAgingCharDeaf shouldBe Some(true)
+    recentAgingCharsMapped.eolRecentAgingCharWeightloss shouldBe Some(true)
+    recentAgingCharsMapped.eolRecentAgingCharRecognition shouldBe Some(true)
+    recentAgingCharsMapped.eolRecentAgingCharOther shouldBe Some(true)
+    recentAgingCharsMapped.eolRecentAgingCharOtherDescription shouldBe
+      Some("Other description")
+  }
+}

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -82,11 +82,6 @@
         }
     ],
     "table_fragments": [
-        "eols_new_condition",
-        "eols_recent_aging_char",
-        "eols_recent_symptom",
-        "eols_death",
-        "eols_euthan",
-        "eols_illness"
+        "eols_recent_aging_char"
     ]
 }


### PR DESCRIPTION
## Why
Extending the DAP End of Life Survey pipeline to add the recent_aging_characteristics Jade fragment.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1803)

## This PR
Added transformation code for the eols_recent_aging_chars fragment
Removed unused fragments from eols schema + general transformations code to resolve runtime errors
Added a unit test for the new transformation log

## Checklist
- [ ] Documentation has been updated as needed.
