### PR TITLE
Extend EOLS transformations code to process eol_med_symptoms fields

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -35,7 +35,8 @@ object EolsTransformations {
           eolNotesDescription = rawRecord.getOptional("eol_notes"),
           eolAddVemr = rawRecord.getOptionalBoolean("eol_add_med_record_yn"),
           // todo: add eolsNewCondition
-          eolsRecentAgingChar = Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
+          eolsRecentAgingChar =
+            Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
           eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord))
           // todo: add eolsDeath
           // todo: add eolsEuthan

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -35,8 +35,8 @@ object EolsTransformations {
           eolNotesDescription = rawRecord.getOptional("eol_notes"),
           eolAddVemr = rawRecord.getOptionalBoolean("eol_add_med_record_yn"),
           // todo: add eolsNewCondition
-          eolsRecentAgingChar = Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord))
-          // todo: add eolsRecentSymptom
+          eolsRecentAgingChar = Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
+          eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord))
           // todo: add eolsDeath
           // todo: add eolsEuthan
           // todo: add eolsIllness

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformations.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsRecentSymptom
+
+object RecentSymptomsTransformations {
+
+  /**
+    * Parse all eol_med_symptoms data out of a raw RedCap record,
+    * injecting them into a partially-modeled Eols record.
+    */
+  def mapRecentSymptoms(rawRecord: RawRecord): EolsRecentSymptom = {
+    val recentSymptoms = Some(rawRecord.getArray("eol_med_symptoms").map(_.toLong))
+    val otherRecentSymptoms = recentSymptoms.map(_.contains(98L))
+    val qolDeclineReason = rawRecord.getOptionalNumber("eol_contribute_qol_decined")
+    EolsRecentSymptom(
+      eolRecentSymptomNone = recentSymptoms.map(_.contains(0L)),
+      eolRecentSymptomLethargy = recentSymptoms.map(_.contains(1L)),
+      eolRecentSymptomVomiting = recentSymptoms.map(_.contains(2L)),
+      eolRecentSymptomDiarrhea = recentSymptoms.map(_.contains(3L)),
+      eolRecentSymptomAppetite = recentSymptoms.map(_.contains(4L)),
+      eolRecentSymptomWeight = recentSymptoms.map(_.contains(5L)),
+      eolRecentSymptomCoughing = recentSymptoms.map(_.contains(6L)),
+      eolRecentSymptomSneezing = recentSymptoms.map(_.contains(7L)),
+      eolRecentSymptomBreathing = recentSymptoms.map(_.contains(8L)),
+      eolRecentSymptomBleedingBruising = recentSymptoms.map(_.contains(9L)),
+      eolRecentSymptomDrinkLot = recentSymptoms.map(_.contains(10L)),
+      eolRecentSymptomDrinkLittle = recentSymptoms.map(_.contains(11L)),
+      eolRecentSymptomUrinating = recentSymptoms.map(_.contains(12L)),
+      eolRecentSymptomIncontinence = recentSymptoms.map(_.contains(13L)),
+      eolRecentSymptomSores = recentSymptoms.map(_.contains(14L)),
+      eolRecentSymptomSeizures = recentSymptoms.map(_.contains(15L)),
+      eolRecentSymptomSwolenAbdomen = recentSymptoms.map(_.contains(16L)),
+      eolRecentSymptomOther = otherRecentSymptoms,
+      eolRecentSymptomOtherDescription =
+        if (otherRecentSymptoms.contains(true))
+          rawRecord.getOptional("eol_med_symptoms_specify")
+        else None,
+      eolRecentQol = rawRecord.getOptionalNumber("eol_qol"),
+      eolQolDeclined = rawRecord.getOptionalNumber("eol_qol_declined"),
+      eolQolDeclinedReason = qolDeclineReason,
+      eolQolDeclinedReasonOtherDescription =
+        if (qolDeclineReason.contains(98L))
+          rawRecord.getOptional("eol_qol_declined_specify")
+        else None,
+      eolRecentVetDiscuss = rawRecord.getOptionalNumber("eol_vet_discuss_yn"),
+      eolRecentVetStay = rawRecord.getOptionalNumber("eol_stayed_at_vet"),
+      eolRecentVetStayLength = rawRecord.getOptionalNumber("eol_length_stayed_at_vet"),
+      eolRecentSedation = rawRecord.getOptionalNumber("eol_sedation_yn"),
+      eolUnderstandPrognosis = rawRecord.getOptionalNumber("eol_understand_prognosis")
+    )
+  }
+}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformationsSpec.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.monster.dap.dog
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dap.eols.RecentSymptomsTransformations
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RecentSymptomsTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  behavior of "RecentSymptomsTransformations"
+
+  it should "map recent medical symptoms where available" in {
+    val recentMedSymptoms = Map(
+      "eol_med_symptoms" -> Array("1", "5", "16", "98"),
+      "eol_med_symptoms_specify" -> Array("Other description"),
+      "eol_qol" -> Array("7"),
+      "eol_qol_declined" -> Array("4"),
+      "eol_contribute_qol_decined" -> Array("98"),
+      "eol_qol_declined_specify" -> Array("Other contributing factor"),
+      "eol_vet_discuss_yn" -> Array("1"),
+      "eol_stayed_at_vet" -> Array("1"),
+      "eol_length_stayed_at_vet" -> Array("1"),
+      "eol_sedation_yn" -> Array("9"),
+      "eol_understand_prognosis" -> Array("5")
+    )
+
+    val recentSymptomsMapped = RecentSymptomsTransformations.mapRecentSymptoms(
+      RawRecord(1, recentMedSymptoms)
+    )
+
+    // output of the example record's recent symptoms transformations
+    recentSymptomsMapped.eolRecentSymptomLethargy shouldBe Some(true)
+    recentSymptomsMapped.eolRecentSymptomWeight shouldBe Some(true)
+    recentSymptomsMapped.eolRecentSymptomSwolenAbdomen shouldBe Some(true)
+    recentSymptomsMapped.eolRecentSymptomOther shouldBe Some(true)
+    recentSymptomsMapped.eolRecentSymptomOtherDescription shouldBe
+      Some("Other description")
+    recentSymptomsMapped.eolRecentQol shouldBe Some(7L)
+    recentSymptomsMapped.eolQolDeclined shouldBe Some(4L)
+    recentSymptomsMapped.eolQolDeclinedReason shouldBe Some(98L)
+    recentSymptomsMapped.eolQolDeclinedReasonOtherDescription shouldBe
+      Some("Other contributing factor")
+    recentSymptomsMapped.eolRecentVetDiscuss shouldBe Some(1L)
+    recentSymptomsMapped.eolRecentVetStay shouldBe Some(1L)
+    recentSymptomsMapped.eolRecentVetStayLength shouldBe Some(1L)
+    recentSymptomsMapped.eolRecentSedation shouldBe Some(9L)
+    recentSymptomsMapped.eolUnderstandPrognosis shouldBe Some(5L)
+  }
+}

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -82,6 +82,7 @@
         }
     ],
     "table_fragments": [
-        "eols_recent_aging_char"
+        "eols_recent_aging_char",
+        "eols_recent_symptom"
     ]
 }


### PR DESCRIPTION
## Why
Extending the DAP End of Life Survey pipeline to add the recent_symptom Jade fragment.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1804)

## This PR
- Added eols_recent_symptom fragment to eols schema and added a call to the new transformation code in eols general transformations
- Added the transformation logic to process recent symptoms fields along with a unit test

## Checklist
- [ ] Documentation has been updated as needed.
