### PR TITLE
Extend EOLS transformations code to process euthanasia fields

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -38,9 +38,9 @@ object EolsTransformations {
           eolsNewCondition = Some(NewConditionTransformations.mapNewConditionMetadata(rawRecord)),
           eolsRecentAgingChar =
             Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
-          eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord))
+          eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord)),
           // todo: add eolsDeath
-          // todo: add eolsEuthan
+          eolsEuthan = Some(EuthanasiaTransformations.mapEuthanasiaFields(rawRecord))
           // todo: add eolsIllness
         )
       )

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformations.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsEuthan
+
+object EuthanasiaTransformations {
+
+  /**
+    * Parse all eol_euthan data out of a raw RedCap record,
+    * injecting them into a partially-modeled Eols record.
+    */
+  def mapEuthanasiaFields(rawRecord: RawRecord): EolsEuthan = {
+    val euthanasiaWho = rawRecord.getOptionalNumber("eol_euthan_who")
+    val euthanasiaWhy = rawRecord.getOptionalNumber("eol_euthan_why1")
+    val euthanasiaWhy2 = Some(rawRecord.getArray("eol_euthan_why2").map(_.toLong))
+    val euthanasiaWhyOther = euthanasiaWhy2.map(_.contains(98L))
+    EolsEuthan(
+      eolEuthan = rawRecord.getOptionalBoolean("eol_euthan_yn"),
+      eolEuthanWho = euthanasiaWho,
+      eolEuthanWhoOtherDescription =
+        if (euthanasiaWho.contains(98)) rawRecord.getOptional("eol_euthan_who_specify") else None,
+      eolEuthanMainReason = euthanasiaWhy,
+      eolEuthanMainReasonOtherDescription =
+        if (euthanasiaWhy.contains(98)) rawRecord.getOptional("eol_euthan_why1_specify") else None,
+      eolEuthanAddReasonNone = euthanasiaWhy2.map(_.contains(0L)),
+      eolEuthanAddReasonQualityOfLife = euthanasiaWhy2.map(_.contains(1L)),
+      eolEuthanAddReasonPain = euthanasiaWhy2.map(_.contains(2L)),
+      eolEuthanAddReasonPrognosis = euthanasiaWhy2.map(_.contains(3L)),
+      eolEuthanAddReasonMedicProb = euthanasiaWhy2.map(_.contains(4L)),
+      eolEuthanAddReasonBehaviorProb = euthanasiaWhy2.map(_.contains(5L)),
+      eolEuthanAddReasonHarmToAnother = euthanasiaWhy2.map(_.contains(6L)),
+      eolEuthanAddReasonIncompatible = euthanasiaWhy2.map(_.contains(7L)),
+      eolEuthanAddReasonCost = euthanasiaWhy2.map(_.contains(8L)),
+      eolEuthanAddReasonOther = euthanasiaWhyOther,
+      eolEuthanAddReasonOtherDescription =
+        if (euthanasiaWhyOther.contains(true))
+          rawRecord.getOptional("eol_euthan_why2_specify")
+        else None
+    )
+  }
+}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformationsSpec.scala
@@ -1,0 +1,63 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EuthanasiaTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  behavior of "EuthanasiaTransformations"
+
+  it should "map euthanasia data where available" in {
+    val euthanasiaData = Map(
+      "eol_euthan_yn" -> Array("1"),
+      "eol_euthan_who" -> Array("1"),
+      "eol_euthan_why1" -> Array("2"),
+      "eol_euthan_why2" -> Array("0", "1", "2", "3", "4")
+    )
+
+    val euthanasiaMapped = EuthanasiaTransformations.mapEuthanasiaFields(
+      RawRecord(1, euthanasiaData)
+    )
+
+    // output of the example record's euthanasia transformations
+    euthanasiaMapped.eolEuthan shouldBe Some(true)
+    euthanasiaMapped.eolEuthanWho shouldBe Some(1L)
+    euthanasiaMapped.eolEuthanMainReason shouldBe Some(2L)
+    euthanasiaMapped.eolEuthanAddReasonNone shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonQualityOfLife shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonPain shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonPrognosis shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonMedicProb shouldBe Some(true)
+  }
+
+  it should "map other responses where available" in {
+    val euthanasiaData = Map(
+      "eol_euthan_yn" -> Array("1"),
+      "eol_euthan_who" -> Array("98"),
+      "eol_euthan_who_specify" -> Array("A professional euthanasia service"),
+      "eol_euthan_why1" -> Array("98"),
+      "eol_euthan_why1_specify" -> Array("Other reason not listed"),
+      "eol_euthan_why2" -> Array("5", "6", "7", "8", "98"),
+      "eol_euthan_why2_specify" -> Array("Some other reason")
+    )
+
+    val euthanasiaMapped = EuthanasiaTransformations.mapEuthanasiaFields(
+      RawRecord(1, euthanasiaData)
+    )
+
+    // output of the example record's euthanasia transformations
+    euthanasiaMapped.eolEuthan shouldBe Some(true)
+    euthanasiaMapped.eolEuthanWho shouldBe Some(98L)
+    euthanasiaMapped.eolEuthanWhoOtherDescription shouldBe Some("A professional euthanasia service")
+    euthanasiaMapped.eolEuthanMainReason shouldBe Some(98L)
+    euthanasiaMapped.eolEuthanMainReasonOtherDescription shouldBe Some("Other reason not listed")
+    euthanasiaMapped.eolEuthanAddReasonBehaviorProb shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonHarmToAnother shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonIncompatible shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonCost shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonOther shouldBe Some(true)
+    euthanasiaMapped.eolEuthanAddReasonOtherDescription shouldBe Some("Some other reason")
+  }
+}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformationsSpec.scala
@@ -1,7 +1,6 @@
-package org.broadinstitute.monster.dap.dog
+package org.broadinstitute.monster.dap.eols
 
 import org.broadinstitute.monster.dap.common.RawRecord
-import org.broadinstitute.monster.dap.eols.RecentSymptomsTransformations
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -84,6 +84,7 @@
     "table_fragments": [
         "eols_new_condition",
         "eols_recent_aging_char",
-        "eols_recent_symptom"
+        "eols_recent_symptom",
+        "eols_euthan"
     ]
 }


### PR DESCRIPTION
## Why
Extending the DAP End of Life Survey pipeline to add the "euthan" Jade fragment.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1806)

## This PR

- Added the eol_euthan fragment to the main eols table schema and general transformations
- Added a script to transform euthanasia related fields
- Added unit tests
- Refactoring imports for RecentSymptomsTransformations

## Checklist
- [ ] Documentation has been updated as needed.
