### PR TITLE
Create Death transformation EOLS DAP

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
@@ -8,6 +8,7 @@ object DeathTransformations {
   def mapDeathTransformations(rawRecord: RawRecord): EolsDeath = {
     val deathLocation = rawRecord.getOptionalNumber("eol_death_location")
     val deathWitness = rawRecord.fields.get("eol_who_present")
+    val deathWitnessOther = deathWitness.map(_.contains("98"))
     EolsDeath(
       eolDeathLocation = deathLocation,
       eolDeathLocationOtherDescription =
@@ -20,9 +21,9 @@ object DeathTransformations {
       eolDeathWitnessWhoAcquaintance = deathWitness.map(_.contains("3")),
       eolDeathWitnessWhoVet = deathWitness.map(_.contains("4")),
       eolDeathWitnessWhoBoarder = deathWitness.map(_.contains("5")),
-      eolDeathWitnessWhoOther = deathWitness.map(_.contains("98")),
+      eolDeathWitnessWhoOther = deathWitnessOther,
       eolDeathWitnessWhoOtherDescription =
-        if (deathWitness.map(_.contains("98")).contains(true))
+        if (deathWitness.contains(true))
           rawRecord.getOptional("eol_who_present_specify")
         else None
     )

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsDeath
+
+object DeathTransformations {
+
+  def mapDeathTransformations(rawRecord: RawRecord): EolsDeath = {
+    val deathLocation = rawRecord.getOptionalNumber("eol_death_location")
+    val deathWitness = rawRecord.fields.get("eol_who_present")
+    EolsDeath(
+      eolDeathLocation = deathLocation,
+      eolDeathLocationOtherDescription =
+        if (deathLocation.contains(98))
+          rawRecord.getOptional("eol_death_location_specify")
+        else None,
+      eolDeathWitness = rawRecord.getOptionalNumber("eol_anyone_present"),
+      eolDeathWitnessWhoYou = deathWitness.map(_.contains("1")),
+      eolDeathWitnessWhoFamily = deathWitness.map(_.contains("2")),
+      eolDeathWitnessWhoAcquaintance = deathWitness.map(_.contains("3")),
+      eolDeathWitnessWhoVet = deathWitness.map(_.contains("4")),
+      eolDeathWitnessWhoBoarder = deathWitness.map(_.contains("5")),
+      eolDeathWitnessWhoOther = deathWitness.map(_.contains("98")),
+      eolDeathWitnessWhoOtherDescription =
+        if (deathWitness.map(_.contains("98")).contains(true))
+          rawRecord.getOptional("eol_who_present_specify")
+        else None
+    )
+  }
+}

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -39,8 +39,8 @@ object EolsTransformations {
           eolsRecentAgingChar =
             Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
           eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord)),
-          // todo: add eolsDeath
-          eolsEuthan = Some(EuthanasiaTransformations.mapEuthanasiaFields(rawRecord))
+          eolsEuthan = Some(EuthanasiaTransformations.mapEuthanasiaFields(rawRecord)),
+          eolsDeath = Some(DeathTransformations.mapDeathTransformations(rawRecord))
           // todo: add eolsIllness
         )
       )

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/DeathTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/DeathTransformationsSpec.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DeathTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+  behavior of "DeathTransformations"
+
+  it should "map death transformations variables where complete" in {
+    val DeathTransform = Map(
+      "eol_death_location" -> Array("1"),
+      "eol_anyone_present" -> Array("1"),
+      "eol_who_present" -> Array("1", "2"),
+      "eol_death_witness_who_you" -> Array("true"),
+      "eol_death_witness_who_family" -> Array("true")
+    )
+
+    val deathMapped = DeathTransformations.mapDeathTransformations(
+      RawRecord(1, DeathTransform)
+    )
+
+    deathMapped.eolDeathLocation.value shouldBe 1L
+    deathMapped.eolDeathWitness.value shouldBe 1L
+    deathMapped.eolDeathWitnessWhoYou.value shouldBe true
+    deathMapped.eolDeathWitnessWhoFamily.value shouldBe true
+  }
+}

--- a/schema/src/main/jade-fragments/eols_death.fragment.json
+++ b/schema/src/main/jade-fragments/eols_death.fragment.json
@@ -15,27 +15,27 @@
         },
         {
             "name": "eol_death_witness_who_you",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_family",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_acquaintance",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_vet",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_boarder",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_other",
-            "datatype": "integer"
+            "datatype": "boolean"
         },
         {
             "name": "eol_death_witness_who_other_description",

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -85,6 +85,7 @@
         "eols_new_condition",
         "eols_recent_aging_char",
         "eols_recent_symptom",
-        "eols_euthan"
+        "eols_euthan",
+        "eols_death"
     ]
 }


### PR DESCRIPTION
## Why
Need to extend DAP End of Life Survey to contain "death" transformations
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1805)

## This PR
Adds Death transformations to EOLS
Add unit tests
Update eols json schema
Change datatypes for some elements in schema

## Checklist
- [ ] Documentation has been updated as needed.
