### PR TITLE
Extend EOLS transformations code to process illness fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ sample_id as well as some other metadata about the sample.
 * Rows in the final Environment table will be unique on _sample_id_.
 
 
+## EOLS Data
+The End of Life Survey is administered when a dog enrolled in the study has passed away.
+The goal of this survey is to collect information about the circumstances surrounding 
+the end of the dog's life and any information available regarding the cause of death.
+
+#### EOLS Extraction Criteria
+* Pull all records from the baseline arm (*baseline_arm_1*) 
+* where _eol_willing_to_complete_ is marked as complete.
+
+#### EOLS Schema Design
+Eols data is also modeled closely to a DAP provided proto-schema which we converted to a repo schema. 
+We decided to break the larger table up into smaller fragments: 
+_new_condition, recent_aging_char, recent_symptom, death, euthan, and illness_ variables.
+
+* A single `eols` table which contains a single Eols record per dog. 
+* The table includes all eols variables and a foreign key to the dog table. 
+* Rows in the final eols table will be unique on _dog_id_.
+
+
 ## Label Mapping Table
 We have a manually maintained lookup table that we are constructing using the Terra JSON schema for the DAP tables and 
 the DAP data dictionaries provided from RedCap. The table contains a row for each field in the the final dog aging tables.

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -40,8 +40,8 @@ object EolsTransformations {
             Some(RecentAgingCharsTransformations.mapRecentAgingChars(rawRecord)),
           eolsRecentSymptom = Some(RecentSymptomsTransformations.mapRecentSymptoms(rawRecord)),
           // todo: add eolsDeath
-          eolsEuthan = Some(EuthanasiaTransformations.mapEuthanasiaFields(rawRecord))
-          // todo: add eolsIllness
+          eolsEuthan = Some(EuthanasiaTransformations.mapEuthanasiaFields(rawRecord)),
+          eolsIllness = Some(IllnessTransformations.mapIllnessFields(rawRecord))
         )
       )
     } else {

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
@@ -1,0 +1,98 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.fragment.EolsIllness
+
+object IllnessTransformations {
+
+  /**
+    * Parse all eol_euthan data out of a raw RedCap record,
+    * injecting them into a partially-modeled Eols record.
+    */
+  def mapIllnessFields(rawRecord: RawRecord): EolsIllness = {
+    val cancerConditions = Some(rawRecord.getArray("eol_cancer_a").map(_.toLong))
+    val otherCancerCondition = cancerConditions.map(_.contains(98L))
+    val cancerNameKnown = rawRecord.getOptionalNumber("eol_cancer_b")
+    val infectionName = rawRecord.getOptionalNumber("eol_infection_a")
+    val infectionSystem = rawRecord.getOptionalNumber("eol_infection_b")
+    val otherIllness = rawRecord.getOptionalNumber("eol_otherillness_a")
+    val diagnosisKnown = rawRecord.getOptionalBoolean("eol_otherillness_b")
+    val illnessTreatment = rawRecord.getOptionalNumber("eol_illness_c")
+    EolsIllness(
+      eolIllnessType = rawRecord.getOptionalNumber("eol_illness_a"),
+      eolIllnessCancerAdrenal = cancerConditions.map(_.contains(1L)),
+      eolIllnessCancerAnalSac = cancerConditions.map(_.contains(2L)),
+      eolIllnessCancerBladderUrethra = cancerConditions.map(_.contains(3L)),
+      eolIllnessCancerBlood = cancerConditions.map(_.contains(4L)),
+      eolIllnessCancerBoneJoint = cancerConditions.map(_.contains(5L)),
+      eolIllnessCancerBrain = cancerConditions.map(_.contains(6L)),
+      eolIllnessCancerMammary = cancerConditions.map(_.contains(7L)),
+      eolIllnessCancerCardiac = cancerConditions.map(_.contains(8L)),
+      eolIllnessCancerEar = cancerConditions.map(_.contains(9L)),
+      eolIllnessCancerEsophagus = cancerConditions.map(_.contains(10L)),
+      eolIllnessCancerEye = cancerConditions.map(_.contains(11L)),
+      eolIllnessCancerGallbladder = cancerConditions.map(_.contains(12L)),
+      eolIllnessCancerGastro = cancerConditions.map(_.contains(13L)),
+      eolIllnessCancerKidney = cancerConditions.map(_.contains(14L)),
+      eolIllnessCancerLiver = cancerConditions.map(_.contains(15L)),
+      eolIllnessCancerLung = cancerConditions.map(_.contains(16L)),
+      eolIllnessCancerLymphNodes = cancerConditions.map(_.contains(17L)),
+      eolIllnessCancerMuscle = cancerConditions.map(_.contains(18L)),
+      eolIllnessCancerNose = cancerConditions.map(_.contains(19L)),
+      eolIllnessCancerNerveSheath = cancerConditions.map(_.contains(20L)),
+      eolIllnessCancerOral = cancerConditions.map(_.contains(21L)),
+      eolIllnessCancerOvaryUterus = cancerConditions.map(_.contains(22L)),
+      eolIllnessCancerPancreas = cancerConditions.map(_.contains(23L)),
+      eolIllnessCancerPerianal = cancerConditions.map(_.contains(24L)),
+      eolIllnessCancerPituitary = cancerConditions.map(_.contains(25L)),
+      eolIllnessCancerProstate = cancerConditions.map(_.contains(26L)),
+      eolIllnessCancerRectum = cancerConditions.map(_.contains(27L)),
+      eolIllnessCancerSkinTrunkBodyHead = cancerConditions.map(_.contains(28L)),
+      eolIllnessCancerSkinLimbFood = cancerConditions.map(_.contains(29L)),
+      eolIllnessCancerSpinalCord = cancerConditions.map(_.contains(30L)),
+      eolIllnessCancerSpleen = cancerConditions.map(_.contains(31L)),
+      eolIllnessCancerTesticle = cancerConditions.map(_.contains(32L)),
+      eolIllnessCancerThyroid = cancerConditions.map(_.contains(33L)),
+      eolIllnessCancerVenereal = cancerConditions.map(_.contains(34L)),
+      eolIllnessCancerUnidentifiedThorax = cancerConditions.map(_.contains(35L)),
+      eolIllnessCancerUnidentifiedAbdomen = cancerConditions.map(_.contains(36L)),
+      eolIllnessCancerUnknown = cancerConditions.map(_.contains(99L)),
+      eolIllnessCancerOther = otherCancerCondition,
+      eolIllnessCancerOtherDescription =
+        if (otherCancerCondition.contains(true))
+          rawRecord.getOptional("eol_cancer_a_specify")
+        else None,
+      eolIlllnessCancerNameKnown = cancerNameKnown,
+      eolIllnessCancerNameDescription =
+        if (cancerNameKnown.contains(1L))
+          rawRecord.getOptional("eol_cancer_b_specify")
+        else None,
+      eolIllnessInfection = infectionName,
+      eolIllnessInfectionOtherDescription =
+        if (infectionName.contains(98L))
+          rawRecord.getOptional("eol_infection_a_specify")
+        else None,
+      eolIllnessInfectionSystem = infectionSystem,
+      eolIllnessInfectionSystemOtherDescription =
+        if (infectionSystem.contains(98L))
+          rawRecord.getOptional("eol_infection_b_specify")
+        else None,
+      eolIllnessOther = otherIllness,
+      eolIllnessOtherOtherDescription =
+        if (otherIllness.contains(98L))
+          rawRecord.getOptional("eol_otherillness_a_specify")
+        else None,
+      eolIllnessOtherDiagnosis = diagnosisKnown,
+      eolIllnessOtherDiagnosisDescription =
+        if (diagnosisKnown.contains(true))
+          rawRecord.getOptional("eol_otherillness_b_specify")
+        else None,
+      eolIllnessAwarenessTimeframe = rawRecord.getOptionalNumber("eol_illness_b"),
+      eolIllnessTreatment = illnessTreatment,
+      eolIllnessTreatmentOtherDescription =
+        if (illnessTreatment.contains(98L))
+          rawRecord.getOptional("eol_illness_c_explain")
+        else None
+    )
+  }
+}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/IllnessTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/IllnessTransformationsSpec.scala
@@ -1,0 +1,128 @@
+package org.broadinstitute.monster.dap.eols
+
+import org.broadinstitute.monster.dap.common.RawRecord
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class IllnessTransformationsSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  behavior of "IllnessTransformations"
+
+  it should "map illnesses caused by cancer" in {
+    val cancerData = Map(
+      "eol_illness_a" -> Array("1"),
+      "eol_cancer_a" -> Array("1", "12", "21", "34", "98"),
+      "eol_cancer_a_specify" -> Array("Some other type of cancer"),
+      "eol_cancer_b" -> Array("1"),
+      "eol_cancer_b_specify" -> Array("New type of cancer"),
+      "eol_illness_b" -> Array("0"),
+      "eol_illness_c" -> Array("7")
+    )
+
+    val cancerMapped = IllnessTransformations.mapIllnessFields(
+      RawRecord(1, cancerData)
+    )
+
+    // output of the example record's illness transformations
+    cancerMapped.eolIllnessType shouldBe Some(1L)
+    cancerMapped.eolIllnessCancerAdrenal shouldBe Some(true)
+    cancerMapped.eolIllnessCancerGallbladder shouldBe Some(true)
+    cancerMapped.eolIllnessCancerOral shouldBe Some(true)
+    cancerMapped.eolIllnessCancerVenereal shouldBe Some(true)
+    cancerMapped.eolIllnessCancerOther shouldBe Some(true)
+    cancerMapped.eolIllnessCancerOtherDescription shouldBe Some("Some other type of cancer")
+    cancerMapped.eolIlllnessCancerNameKnown shouldBe Some(1L)
+    cancerMapped.eolIllnessCancerNameDescription shouldBe Some("New type of cancer")
+    cancerMapped.eolIllnessAwarenessTimeframe shouldBe Some(0L)
+    cancerMapped.eolIllnessTreatment shouldBe Some(7L)
+  }
+
+  it should "map illnesses caused by infection" in {
+    val infectionData = Map(
+      "eol_illness_a" -> Array("2"),
+      "eol_infection_a" -> Array("21"),
+      "eol_infection_b" -> Array("16"),
+      "eol_illness_b" -> Array("3"),
+      "eol_illness_c" -> Array("1")
+    )
+
+    val infectionMapped = IllnessTransformations.mapIllnessFields(
+      RawRecord(1, infectionData)
+    )
+
+    // output of the example record's illness transformations
+    infectionMapped.eolIllnessType shouldBe Some(2L)
+    infectionMapped.eolIllnessInfection shouldBe Some(21L)
+    infectionMapped.eolIllnessInfectionSystem shouldBe Some(16L)
+    infectionMapped.eolIllnessAwarenessTimeframe shouldBe Some(3L)
+    infectionMapped.eolIllnessTreatment shouldBe Some(1L)
+  }
+
+  it should "map illnesses caused by other types of infection" in {
+    val infectionData = Map(
+      "eol_illness_a" -> Array("2"),
+      "eol_infection_a" -> Array("98"),
+      "eol_infection_a_specify" -> Array("Other type of infection"),
+      "eol_infection_b" -> Array("98"),
+      "eol_infection_b_specify" -> Array("Other body system"),
+      "eol_illness_b" -> Array("4"),
+      "eol_illness_c" -> Array("6")
+    )
+
+    val infectionMapped = IllnessTransformations.mapIllnessFields(
+      RawRecord(1, infectionData)
+    )
+
+    // output of the example record's illness transformations
+    infectionMapped.eolIllnessType shouldBe Some(2L)
+    infectionMapped.eolIllnessInfection shouldBe Some(98L)
+    infectionMapped.eolIllnessInfectionOtherDescription shouldBe Some("Other type of infection")
+    infectionMapped.eolIllnessInfectionSystem shouldBe Some(98L)
+    infectionMapped.eolIllnessInfectionSystemOtherDescription shouldBe Some("Other body system")
+    infectionMapped.eolIllnessAwarenessTimeframe shouldBe Some(4L)
+    infectionMapped.eolIllnessTreatment shouldBe Some(6L)
+  }
+
+  it should "map illnesses caused by other diseases" in {
+    val otherIllnessData = Map(
+      "eol_illness_a" -> Array("3"),
+      "eol_otherillness_a" -> Array("98"),
+      "eol_otherillness_a_specify" -> Array("Other type of illness"),
+      "eol_otherillness_b" -> Array("1"),
+      "eol_otherillness_b_specify" -> Array("Specific diagnosis")
+    )
+
+    val otherIllnessMapped = IllnessTransformations.mapIllnessFields(
+      RawRecord(1, otherIllnessData)
+    )
+
+    // output of the example record's illness transformations
+    otherIllnessMapped.eolIllnessType shouldBe Some(3L)
+    otherIllnessMapped.eolIllnessOther shouldBe Some(98L)
+    otherIllnessMapped.eolIllnessOtherOtherDescription shouldBe Some("Other type of illness")
+    otherIllnessMapped.eolIllnessOtherDiagnosis shouldBe Some(true)
+    otherIllnessMapped.eolIllnessOtherDiagnosisDescription shouldBe Some("Specific diagnosis")
+  }
+
+  it should "map illnesses caused by unknown reasons" in {
+    val addIllnessData = Map(
+      "eol_illness_a" -> Array("99"),
+      "eol_illness_b" -> Array("2"),
+      "eol_illness_c" -> Array("98"),
+      "eol_illness_c_explain" -> Array("Additional treatment information")
+    )
+
+    val addIllnessMapped = IllnessTransformations.mapIllnessFields(
+      RawRecord(1, addIllnessData)
+    )
+
+    // output of the example record's illness transformations
+    addIllnessMapped.eolIllnessType shouldBe Some(99L)
+    addIllnessMapped.eolIllnessAwarenessTimeframe shouldBe Some(2L)
+    addIllnessMapped.eolIllnessTreatment shouldBe Some(98L)
+    addIllnessMapped.eolIllnessTreatmentOtherDescription shouldBe Some(
+      "Additional treatment information"
+    )
+  }
+}

--- a/hack/convert-output-to-tsv.py
+++ b/hack/convert-output-to-tsv.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 TERRA_COLUMN_LIMIT = 1000
 
 table_names = args.table or ['cslb', 'hles_cancer_condition', 'hles_dog', 'hles_health_condition', 'hles_owner',
-                             'environment', 'sample']
+                             'environment', 'sample', 'eols']
 PRIMARY_KEY_PREFIX = 'entity'
 
 gcs = GCSFileSystem()
@@ -49,7 +49,7 @@ class PrimaryKeyGenerator:
     # this will calculate pk_name during init
     def __post_init__(self):
         # most tables should have "dog_id" as a key
-        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb"}:
+        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb", "eols"}:
             self.pk_name = 'dog_id'
         # owner table is linked to hles_dog via "owner_id"
         elif self.table_name == 'hles_owner':

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -85,6 +85,7 @@
         "eols_new_condition",
         "eols_recent_aging_char",
         "eols_recent_symptom",
-        "eols_euthan"
+        "eols_euthan",
+        "eols_illness"
     ]
 }


### PR DESCRIPTION
## Why
Extending the DAP End of Life Survey pipeline to add the "illnesses" Jade fragment.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1807)

## This PR
- Added the eol_illness fragment to the main eols table schema and general transformations
- Added a script to transform illness related fields
- Added unit tests for the different types of illnesses as per DAP annotated PDF
- Updated tsv output script to include eols data
- Updated documentation

## Checklist
- [x] Documentation has been updated as needed.
