### PR TITLE
Refactor EOLS Extraction Filters and fix transformation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ the end of the dog's life and any information available regarding the cause of d
 
 #### EOLS Extraction Criteria
 * Pull all records from the baseline arm (*baseline_arm_1*) 
-* where _eol_willing_to_complete_ is marked as complete.
+* where _end_of_life_complete_ and _eol_willing_to_complete_ are marked as complete.
 
 #### EOLS Schema Design
 Eols data is also modeled closely to a DAP provided proto-schema which we converted to a repo schema. 

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
@@ -13,7 +13,7 @@ object DeathTransformations {
       eolDeathLocation = deathLocation,
       eolDeathLocationOtherDescription =
         if (deathLocation.contains(98))
-          rawRecord.getOptional("eol_death_location_specify")
+          rawRecord.getOptionalStripped("eol_death_location_specify")
         else None,
       eolDeathWitness = rawRecord.getOptionalNumber("eol_anyone_present"),
       eolDeathWitnessWhoYou = deathWitness.map(_.contains("1")),
@@ -24,7 +24,7 @@ object DeathTransformations {
       eolDeathWitnessWhoOther = deathWitnessOther,
       eolDeathWitnessWhoOtherDescription =
         if (deathWitness.contains(true))
-          rawRecord.getOptional("eol_who_present_specify")
+          rawRecord.getOptionalStripped("eol_who_present_specify")
         else None
     )
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformationPipelineBuilder.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformationPipelineBuilder.scala
@@ -20,7 +20,8 @@ object EolsTransformationPipelineBuilder extends PipelineBuilder[Args] {
   override def buildPipeline(ctx: ScioContext, args: Args): Unit = {
     val rawRecords = readRecords(ctx, args)
 
-    val eols = rawRecords.transform("EOLS data")(_.map(EolsTransformations.mapEols))
+    val eols =
+      rawRecords.transform("EOLS data")(_.map(EolsTransformations.mapEols).filter(_.isDefined))
 
     StorageIO.writeJsonLists(
       eols,

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EolsTransformations.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.monster.dap.eols
 
 import org.broadinstitute.monster.dap.common.RawRecord
 import org.broadinstitute.monster.dogaging.jadeschema.table.Eols
+import com.spotify.scio.ScioMetrics.counter
 
 object EolsTransformations {
 
@@ -9,30 +10,30 @@ object EolsTransformations {
     * The schema for eols variables has been separated into 6 jade-fragments.
     */
   def mapEols(rawRecord: RawRecord): Option[Eols] = {
-    val dogId = rawRecord.id
     val willingToComplete = rawRecord.getRequiredBoolean("eol_willing_to_complete")
     if (willingToComplete) {
       Some(
         Eols(
-          dogId = dogId,
+          dogId = rawRecord.id,
           eolWillingToComplete = Some(willingToComplete),
           eolExactDeathDateKnown = rawRecord.getOptionalBoolean("eol_know_date_dog_died_yn"),
-          eolDeathDate = rawRecord.getOptional("eol_date_dog_died"),
+          eolDeathDate = rawRecord.getOptionalDate("eol_date_dog_died"),
           eolCauseOfDeathPrimary = rawRecord.getOptionalNumber("eol_cause1_death"),
           eolCauseOfDeathPrimaryOtherDescription =
-            rawRecord.getOptional("eol_cause1_death_specify"),
+            rawRecord.getOptionalStripped("eol_cause1_death_specify"),
           eolCauseOfDeathSecondary = rawRecord.getOptionalNumber("eol_cause2_death"),
           eolCauseOfDeathSecondaryOtherDescription =
-            rawRecord.getOptional("eol_cause2_death_specify"),
+            rawRecord.getOptionalStripped("eol_cause2_death_specify"),
           eolOldAgePrimary = rawRecord.getOptionalNumber("eol_old_age_a"),
-          eolOldAgePrimaryOtherDescription = rawRecord.getOptional("eol_old_age_a_specify"),
+          eolOldAgePrimaryOtherDescription = rawRecord.getOptionalStripped("eol_old_age_a_specify"),
           eolTrauma = rawRecord.getOptionalNumber("eol_trauma_a"),
-          eolTraumaOtherDescription = rawRecord.getOptional("eol_trauma_a_specify"),
+          eolTraumaOtherDescription = rawRecord.getOptionalStripped("eol_trauma_a_specify"),
           eolToxin = rawRecord.getOptionalNumber("eol_toxin_a"),
-          eolToxinOtherDescription = rawRecord.getOptional("eol_toxin_a_specify"),
+          eolToxinOtherDescription = rawRecord.getOptionalStripped("eol_toxin_a_specify"),
           eolOldAgeSecondary = rawRecord.getOptionalNumber("eol_old_age_cod_2"),
-          eolOldAgeSecondaryOtherDescription = rawRecord.getOptional("eol_old_age_cod_2_specify"),
-          eolNotesDescription = rawRecord.getOptional("eol_notes"),
+          eolOldAgeSecondaryOtherDescription =
+            rawRecord.getOptionalStripped("eol_old_age_cod_2_specify"),
+          eolNotesDescription = rawRecord.getOptionalStripped("eol_notes"),
           eolAddVemr = rawRecord.getOptionalBoolean("eol_add_med_record_yn"),
           eolsNewCondition = Some(NewConditionTransformations.mapNewConditionMetadata(rawRecord)),
           eolsRecentAgingChar =
@@ -44,6 +45,7 @@ object EolsTransformations {
         )
       )
     } else {
+      counter("eols", "not_willing_to_complete").inc()
       None
     }
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/EuthanasiaTransformations.scala
@@ -18,10 +18,12 @@ object EuthanasiaTransformations {
       eolEuthan = rawRecord.getOptionalBoolean("eol_euthan_yn"),
       eolEuthanWho = euthanasiaWho,
       eolEuthanWhoOtherDescription =
-        if (euthanasiaWho.contains(98)) rawRecord.getOptional("eol_euthan_who_specify") else None,
+        if (euthanasiaWho.contains(98)) rawRecord.getOptionalStripped("eol_euthan_who_specify")
+        else None,
       eolEuthanMainReason = euthanasiaWhy,
       eolEuthanMainReasonOtherDescription =
-        if (euthanasiaWhy.contains(98)) rawRecord.getOptional("eol_euthan_why1_specify") else None,
+        if (euthanasiaWhy.contains(98)) rawRecord.getOptionalStripped("eol_euthan_why1_specify")
+        else None,
       eolEuthanAddReasonNone = euthanasiaWhy2.map(_.contains(0L)),
       eolEuthanAddReasonQualityOfLife = euthanasiaWhy2.map(_.contains(1L)),
       eolEuthanAddReasonPain = euthanasiaWhy2.map(_.contains(2L)),
@@ -34,7 +36,7 @@ object EuthanasiaTransformations {
       eolEuthanAddReasonOther = euthanasiaWhyOther,
       eolEuthanAddReasonOtherDescription =
         if (euthanasiaWhyOther.contains(true))
-          rawRecord.getOptional("eol_euthan_why2_specify")
+          rawRecord.getOptionalStripped("eol_euthan_why2_specify")
         else None
     )
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
@@ -60,38 +60,38 @@ object IllnessTransformations {
       eolIllnessCancerOther = otherCancerCondition,
       eolIllnessCancerOtherDescription =
         if (otherCancerCondition.contains(true))
-          rawRecord.getOptional("eol_cancer_a_specify")
+          rawRecord.getOptionalStripped("eol_cancer_a_specify")
         else None,
       eolIlllnessCancerNameKnown = cancerNameKnown,
       eolIllnessCancerNameDescription =
         if (cancerNameKnown.contains(1L))
-          rawRecord.getOptional("eol_cancer_b_specify")
+          rawRecord.getOptionalStripped("eol_cancer_b_specify")
         else None,
       eolIllnessInfection = infectionName,
       eolIllnessInfectionOtherDescription =
         if (infectionName.contains(98L))
-          rawRecord.getOptional("eol_infection_a_specify")
+          rawRecord.getOptionalStripped("eol_infection_a_specify")
         else None,
       eolIllnessInfectionSystem = infectionSystem,
       eolIllnessInfectionSystemOtherDescription =
         if (infectionSystem.contains(98L))
-          rawRecord.getOptional("eol_infection_b_specify")
+          rawRecord.getOptionalStripped("eol_infection_b_specify")
         else None,
       eolIllnessOther = otherIllness,
       eolIllnessOtherOtherDescription =
         if (otherIllness.contains(98L))
-          rawRecord.getOptional("eol_otherillness_a_specify")
+          rawRecord.getOptionalStripped("eol_otherillness_a_specify")
         else None,
       eolIllnessOtherDiagnosis = diagnosisKnown,
       eolIllnessOtherDiagnosisDescription =
         if (diagnosisKnown.contains(true))
-          rawRecord.getOptional("eol_otherillness_b_specify")
+          rawRecord.getOptionalStripped("eol_otherillness_b_specify")
         else None,
       eolIllnessAwarenessTimeframe = rawRecord.getOptionalNumber("eol_illness_b"),
       eolIllnessTreatment = illnessTreatment,
       eolIllnessTreatmentOtherDescription =
         if (illnessTreatment.contains(98L))
-          rawRecord.getOptional("eol_illness_c_explain")
+          rawRecord.getOptionalStripped("eol_illness_c_explain")
         else None
     )
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/NewConditionTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/NewConditionTransformations.scala
@@ -55,122 +55,127 @@ object NewConditionTransformations {
       eolNewConditionInfectiousDiseaseYear =
         if (infectiousDisease.contains(true)) rawRecord.getOptionalNumber("eol_dx_year1") else None,
       eolNewConditionInfectiousDiseaseSpecify =
-        if (infectiousDisease.contains(true)) rawRecord.getOptional("eol_dx_specify1") else None,
+        if (infectiousDisease.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify1")
+        else None,
       eolNewConditionToxinConsumptionMonth =
         if (toxinConsumption.contains(true)) rawRecord.getOptionalNumber("eol_dx_month2") else None,
       eolNewConditionToxinConsumptionYear =
         if (toxinConsumption.contains(true)) rawRecord.getOptionalNumber("eol_dx_year2") else None,
       eolNewConditionToxinConsumptionSpecify =
-        if (toxinConsumption.contains(true)) rawRecord.getOptional("eol_dx_specify2") else None,
+        if (toxinConsumption.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify2")
+        else None,
       eolNewConditionTraumaMonth =
         if (trauma.contains(true)) rawRecord.getOptionalNumber("eol_dx_month3") else None,
       eolNewConditionTraumaYear =
         if (trauma.contains(true)) rawRecord.getOptionalNumber("eol_dx_year3") else None,
       eolNewConditionTraumaSpecify =
-        if (trauma.contains(true)) rawRecord.getOptional("eol_dx_specify3") else None,
+        if (trauma.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify3") else None,
       eolNewConditionCancerMonth =
         if (cancer.contains(true)) rawRecord.getOptionalNumber("eol_dx_month4") else None,
       eolNewConditionCancerYear =
         if (cancer.contains(true)) rawRecord.getOptionalNumber("eol_dx_year4") else None,
       eolNewConditionCancerSpecify =
-        if (cancer.contains(true)) rawRecord.getOptional("eol_dx_specify4") else None,
+        if (cancer.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify4") else None,
       eolNewConditionEyeMonth =
         if (eye.contains(true)) rawRecord.getOptionalNumber("eol_dx_month5") else None,
       eolNewConditionEyeYear =
         if (eye.contains(true)) rawRecord.getOptionalNumber("eol_dx_year5") else None,
       eolNewConditionEyeSpecify =
-        if (eye.contains(true)) rawRecord.getOptional("eol_dx_specify5") else None,
+        if (eye.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify5") else None,
       eolNewConditionEarMonth =
         if (ear.contains(true)) rawRecord.getOptionalNumber("eol_dx_month6") else None,
       eolNewConditionEarYear =
         if (ear.contains(true)) rawRecord.getOptionalNumber("eol_dx_year6") else None,
       eolNewConditionEarSpecify =
-        if (ear.contains(true)) rawRecord.getOptional("eol_dx_specify6") else None,
+        if (ear.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify6") else None,
       eolNewConditionOralMonth =
         if (oral.contains(true)) rawRecord.getOptionalNumber("eol_dx_month7") else None,
       eolNewConditionOralYear =
         if (oral.contains(true)) rawRecord.getOptionalNumber("eol_dx_year7") else None,
       eolNewConditionOralSpecify =
-        if (oral.contains(true)) rawRecord.getOptional("eol_dx_specify7") else None,
+        if (oral.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify7") else None,
       eolNewConditionSkinMonth =
         if (skin.contains(true)) rawRecord.getOptionalNumber("eol_dx_month8") else None,
       eolNewConditionSkinYear =
         if (skin.contains(true)) rawRecord.getOptionalNumber("eol_dx_year8") else None,
       eolNewConditionSkinSpecify =
-        if (skin.contains(true)) rawRecord.getOptional("eol_dx_specify8") else None,
+        if (skin.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify8") else None,
       eolNewConditionCardiacMonth =
         if (cardiac.contains(true)) rawRecord.getOptionalNumber("eol_dx_month9") else None,
       eolNewConditionCardiacYear =
         if (cardiac.contains(true)) rawRecord.getOptionalNumber("eol_dx_year9") else None,
       eolNewConditionCardiacSpecify =
-        if (cardiac.contains(true)) rawRecord.getOptional("eol_dx_specify9") else None,
+        if (cardiac.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify9") else None,
       eolNewConditionRespiratoryMonth =
         if (respiratory.contains(true)) rawRecord.getOptionalNumber("eol_dx_month10") else None,
       eolNewConditionRespiratoryYear =
         if (respiratory.contains(true)) rawRecord.getOptionalNumber("eol_dx_year10") else None,
       eolNewConditionRespiratorySpecify =
-        if (respiratory.contains(true)) rawRecord.getOptional("eol_dx_specify10") else None,
+        if (respiratory.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify10") else None,
       eolNewConditionGastrointestinalMonth =
         if (gastrointestinal.contains(true)) rawRecord.getOptionalNumber("eol_dx_month11")
         else None,
       eolNewConditionGastrointestinalYear =
         if (gastrointestinal.contains(true)) rawRecord.getOptionalNumber("eol_dx_year11") else None,
       eolNewConditionGastrointestinalSpecify =
-        if (gastrointestinal.contains(true)) rawRecord.getOptional("eol_dx_specify11") else None,
+        if (gastrointestinal.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify11")
+        else None,
       eolNewConditionLiverMonth =
         if (liver.contains(true)) rawRecord.getOptionalNumber("eol_dx_month12") else None,
       eolNewConditionLiverYear =
         if (liver.contains(true)) rawRecord.getOptionalNumber("eol_dx_year12") else None,
       eolNewConditionLiverSpecify =
-        if (liver.contains(true)) rawRecord.getOptional("eol_dx_specify12") else None,
+        if (liver.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify12") else None,
       eolNewConditionKidneyMonth =
         if (kidney.contains(true)) rawRecord.getOptionalNumber("eol_dx_month13") else None,
       eolNewConditionKidneyYear =
         if (kidney.contains(true)) rawRecord.getOptionalNumber("eol_dx_year13") else None,
       eolNewConditionKidneySpecify =
-        if (kidney.contains(true)) rawRecord.getOptional("eol_dx_specify13") else None,
+        if (kidney.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify13") else None,
       eolNewConditionReproductiveMonth =
         if (reproductive.contains(true)) rawRecord.getOptionalNumber("eol_dx_month14") else None,
       eolNewConditionReproductiveYear =
         if (reproductive.contains(true)) rawRecord.getOptionalNumber("eol_dx_year14") else None,
       eolNewConditionReproductiveSpecify =
-        if (reproductive.contains(true)) rawRecord.getOptional("eol_dx_specify14") else None,
+        if (reproductive.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify14")
+        else None,
       eolNewConditionOrthopedicMonth =
         if (orthopedic.contains(true)) rawRecord.getOptionalNumber("eol_dx_month15") else None,
       eolNewConditionOrthopedicYear =
         if (orthopedic.contains(true)) rawRecord.getOptionalNumber("eol_dx_year15") else None,
       eolNewConditionOrthopedicSpecify =
-        if (orthopedic.contains(true)) rawRecord.getOptional("eol_dx_specify15") else None,
+        if (orthopedic.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify15") else None,
       eolNewConditionNeurologicalMonth =
         if (neurological.contains(true)) rawRecord.getOptionalNumber("eol_dx_month16") else None,
       eolNewConditionNeurologicalYear =
         if (neurological.contains(true)) rawRecord.getOptionalNumber("eol_dx_year16") else None,
       eolNewConditionNeurologicalSpecify =
-        if (neurological.contains(true)) rawRecord.getOptional("eol_dx_specify16") else None,
+        if (neurological.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify16")
+        else None,
       eolNewConditionEndocrineMonth =
         if (endocrine.contains(true)) rawRecord.getOptionalNumber("eol_dx_month17") else None,
       eolNewConditionEndocrineYear =
         if (endocrine.contains(true)) rawRecord.getOptionalNumber("eol_dx_year17") else None,
       eolNewConditionEndocrineSpecify =
-        if (endocrine.contains(true)) rawRecord.getOptional("eol_dx_specify17") else None,
+        if (endocrine.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify17") else None,
       eolNewConditionHomatologicMonth =
         if (homatologic.contains(true)) rawRecord.getOptionalNumber("eol_dx_month18") else None,
       eolNewConditionHomatologicYear =
         if (homatologic.contains(true)) rawRecord.getOptionalNumber("eol_dx_year18") else None,
       eolNewConditionHomatologicSpecify =
-        if (homatologic.contains(true)) rawRecord.getOptional("eol_dx_specify18") else None,
+        if (homatologic.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify18") else None,
       eolNewConditionImmuneMonth =
         if (immune.contains(true)) rawRecord.getOptionalNumber("eol_dx_month19") else None,
       eolNewConditionImmuneYear =
         if (immune.contains(true)) rawRecord.getOptionalNumber("eol_dx_year19") else None,
       eolNewConditionImmuneSpecify =
-        if (immune.contains(true)) rawRecord.getOptional("eol_dx_specify19") else None,
+        if (immune.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify19") else None,
       eolNewConditionOtherMonth =
         if (other.contains(true)) rawRecord.getOptionalNumber("eol_dx_month20") else None,
       eolNewConditionOtherYear =
         if (other.contains(true)) rawRecord.getOptionalNumber("eol_dx_year20") else None,
       eolNewConditionOtherSpecify =
-        if (other.contains(true)) rawRecord.getOptional("eol_dx_specify20") else None
+        if (other.contains(true)) rawRecord.getOptionalStripped("eol_dx_specify20") else None
     )
   }
 }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentAgingCharsTransformations.scala
@@ -35,7 +35,7 @@ object RecentAgingCharsTransformations {
       eolRecentAgingCharOther = otherChar,
       eolRecentAgingCharOtherDescription =
         if (otherChar.contains(true))
-          rawRecord.getOptional("eol_aging_characteristics_specify")
+          rawRecord.getOptionalStripped("eol_aging_characteristics_specify")
         else None
     )
   }

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/RecentSymptomsTransformations.scala
@@ -34,14 +34,14 @@ object RecentSymptomsTransformations {
       eolRecentSymptomOther = otherRecentSymptoms,
       eolRecentSymptomOtherDescription =
         if (otherRecentSymptoms.contains(true))
-          rawRecord.getOptional("eol_med_symptoms_specify")
+          rawRecord.getOptionalStripped("eol_med_symptoms_specify")
         else None,
       eolRecentQol = rawRecord.getOptionalNumber("eol_qol"),
       eolQolDeclined = rawRecord.getOptionalNumber("eol_qol_declined"),
       eolQolDeclinedReason = qolDeclineReason,
       eolQolDeclinedReasonOtherDescription =
         if (qolDeclineReason.contains(98L))
-          rawRecord.getOptional("eol_qol_declined_specify")
+          rawRecord.getOptionalStripped("eol_qol_declined_specify")
         else None,
       eolRecentVetDiscuss = rawRecord.getOptionalNumber("eol_vet_discuss_yn"),
       eolRecentVetStay = rawRecord.getOptionalNumber("eol_stayed_at_vet"),

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/EolsTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/EolsTransformationsSpec.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.monster.dap.eols
 
 import org.broadinstitute.monster.dap.common.RawRecord
 import org.broadinstitute.monster.dogaging.jadeschema.table.Eols
+
+import java.time.LocalDate
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,19 +19,19 @@ class EolsTransformationsSpec extends AnyFlatSpec with Matchers with OptionValue
           Map(
             "eol_willing_to_complete" -> Array("1"),
             "eol_know_date_dog_died_yn" -> Array("1"),
-            "eol_date_dog_died" -> Array("1990-01-01"),
+            "eol_date_dog_died" -> Array("1990-01-30"),
             "eol_cause1_death" -> Array("1"),
             "eol_cause1_death_specify" -> Array("Doggo lived to a ripe old age of 18"),
             "eol_cause2_death" -> Array("7"),
-            "eol_cause2_death_specify" -> Array("He passed away in his sleep"),
+            "eol_cause2_death_specify" -> Array("He passed away\n\nin his sleep"),
             "eol_old_age_a" -> Array("19"),
             "eol_old_age_a_specify" -> Array("He wagged his tail till his last day"),
             "eol_trauma_a" -> Array("98"),
-            "eol_trauma_a_specify" -> Array("He seemed to in and out of consciousness"),
+            "eol_trauma_a_specify" -> Array("He seemed to pass\t in and out of consciousness"),
             "eol_toxin_a" -> Array("98"),
             "eol_toxin_a_specify" -> Array("Other"),
             "eol_old_age_cod_2" -> Array("5"),
-            "eol_old_age_cod_2_specify" -> Array("General soreness and stiffness in the body"),
+            "eol_old_age_cod_2_specify" -> Array("General soreness and stiffness in the body\r\n"),
             "eol_notes" -> Array("Notes on end of life"),
             "eol_add_med_record_yn" -> Array("1")
           )
@@ -39,22 +41,22 @@ class EolsTransformationsSpec extends AnyFlatSpec with Matchers with OptionValue
 
     mapped.eolWillingToComplete shouldBe Some(true)
     mapped.eolExactDeathDateKnown shouldBe Some(true)
-    mapped.eolDeathDate shouldBe Some("1990-01-01")
+    mapped.eolDeathDate.value shouldBe LocalDate.of(1990, 1, 30)
     mapped.eolCauseOfDeathPrimary shouldBe Some(1L)
     mapped.eolCauseOfDeathPrimaryOtherDescription shouldBe Some(
       "Doggo lived to a ripe old age of 18"
     )
     mapped.eolCauseOfDeathSecondary shouldBe Some(7L)
-    mapped.eolCauseOfDeathSecondaryOtherDescription shouldBe Some("He passed away in his sleep")
+    mapped.eolCauseOfDeathSecondaryOtherDescription shouldBe Some("He passed away  in his sleep")
     mapped.eolOldAgePrimary shouldBe Some(19L)
     mapped.eolOldAgePrimaryOtherDescription shouldBe Some("He wagged his tail till his last day")
     mapped.eolTrauma shouldBe Some(98)
-    mapped.eolTraumaOtherDescription shouldBe Some("He seemed to in and out of consciousness")
+    mapped.eolTraumaOtherDescription shouldBe Some("He seemed to pass  in and out of consciousness")
     mapped.eolToxin shouldBe Some(98)
     mapped.eolToxinOtherDescription shouldBe Some("Other")
     mapped.eolOldAgeSecondary shouldBe Some(5L)
     mapped.eolOldAgeSecondaryOtherDescription shouldBe Some(
-      "General soreness and stiffness in the body"
+      "General soreness and stiffness in the body "
     )
     mapped.eolNotesDescription shouldBe Some("Notes on end of life")
     mapped.eolAddVemr shouldBe Some(true)

--- a/schema/src/main/jade-tables/eols.table.json
+++ b/schema/src/main/jade-tables/eols.table.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "eol_death_date",
-            "datatype": "string"
+            "datatype": "date"
         },
         {
             "name": "eol_cause_of_death_primary",


### PR DESCRIPTION
## Why
We need to make some changes to the EOLS pipeline based on some findings in our e2e testing and some feedback from Matt Dunbar on suggested TDR types.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1842)

## This PR
- Refactored the EOLS extraction filters to check for '[form]_complete' and 'eol_willing_to_complete' fields
- Refactored the EOLS pipeline builder code to make sure we are only writing the json for records when they are defined
- Added a counter to catch any records that don't meet the filter criteria
- Replaced getOptional with getOptionalStripped to normalize user text entries
- Updated the datatype for eol_death_date from string -> date
- Updated unit tests

## Checklist
- [x] Documentation has been updated as needed.
