### PR TITLE
Add sample and EOLS dagster dap orchestration to pipeline

### DIFF
--- a/orchestration/dap_orchestration/pipelines.py
+++ b/orchestration/dap_orchestration/pipelines.py
@@ -5,8 +5,9 @@ from dagster_utils.resources.beam.dataflow_beam_runner import dataflow_beam_runn
 
 from dap_orchestration.config import preconfigure_resource_for_mode
 from dap_orchestration.resources import refresh_directory, outfiles_writer
-from dap_orchestration.solids import hles_extract_records, cslb_extract_records, env_extract_records,\
-    hles_transform_records, cslb_transform_records, env_transform_records, write_outfiles
+from dap_orchestration.solids import hles_extract_records, cslb_extract_records, env_extract_records, \
+    sample_extract_records, eols_extract_records, hles_transform_records, cslb_transform_records, \
+    env_transform_records, write_outfiles, sample_transform_records, eols_transform_records
 
 
 local_mode = ModeDefinition(
@@ -53,6 +54,8 @@ def refresh_data_all() -> None:
     collected_outputs = [
         hles_transform_records(hles_extract_records()),
         cslb_transform_records(cslb_extract_records()),
-        env_transform_records(env_extract_records())
+        env_transform_records(env_extract_records()),
+        sample_transform_records(sample_extract_records()),
+        eols_transform_records(eols_extract_records())
     ]
     write_outfiles(collected_outputs)

--- a/orchestration/dap_orchestration/solids.py
+++ b/orchestration/dap_orchestration/solids.py
@@ -20,7 +20,7 @@ class_prefix = "org.broadinstitute.monster.dap"
 def extract_records(context: AbstractComputeExecutionContext) -> None:
     """
     This solid will take in the arguments provided in context and run the sbt extraction code
-    for the predefined pipeline (HLES, CSLB, or ENVIRONMENT) using the specified runner.
+    for the predefined pipeline (HLES, CSLB, ENVIRONMENT, Sample, EOLS) using the specified runner.
     """
     arg_dict = {
         "pullDataDictionaries": "true" if context.solid_config["pull_data_dictionaries"] else "false",

--- a/orchestration/dap_orchestration/solids.py
+++ b/orchestration/dap_orchestration/solids.py
@@ -96,6 +96,40 @@ def env_extract_records(config: dict[str, str]) -> dict[str, str]:
     )
 
 
+@configured(
+    extract_records,
+    config_schema={
+        "pull_data_dictionaries": Bool,
+        "end_time": String,
+        "api_token": String,
+    }
+)
+def sample_extract_records(config: dict[str, str]) -> dict[str, str]:
+    return _build_extract_config(
+        config=config,
+        output_prefix="raw",
+        target_class=f"{class_prefix}.sample.SampleExtractionPipeline",
+        scala_project=extract_project
+    )
+
+
+@configured(
+    extract_records,
+    config_schema={
+        "pull_data_dictionaries": Bool,
+        "end_time": String,
+        "api_token": String,
+    }
+)
+def eols_extract_records(config: dict[str, str]) -> dict[str, str]:
+    return _build_extract_config(
+        config=config,
+        output_prefix="raw",
+        target_class=f"{class_prefix}.eols.EolsExtractionPipeline",
+        scala_project=extract_project
+    )
+
+
 @solid(
     required_resource_keys={"beam_runner", "refresh_directory"},
     config_schema={
@@ -156,6 +190,26 @@ def env_transform_records(config: dict[str, str]) -> dict[str, str]:
         input_prefix="raw/environment",
         output_prefix="transform",
         target_class=f"{class_prefix}.environment.EnvironmentTransformationPipeline",
+        scala_project=transform_project
+    )
+
+
+@configured(transform_records)
+def sample_transform_records(config: dict[str, str]) -> dict[str, str]:
+    return _build_transform_config(
+        input_prefix="raw/sample",
+        output_prefix="transform",
+        target_class=f"{class_prefix}.sample.SampleTransformationPipeline",
+        scala_project=transform_project
+    )
+
+
+@configured(transform_records)
+def eols_transform_records(config: dict[str, str]) -> dict[str, str]:
+    return _build_transform_config(
+        input_prefix="raw/eols",
+        output_prefix="transform",
+        target_class=f"{class_prefix}.eols.EolsTransformationPipeline",
         scala_project=transform_project
     )
 

--- a/orchestration/dap_orchestration/tests/test_pipelines.py
+++ b/orchestration/dap_orchestration/tests/test_pipelines.py
@@ -36,6 +36,20 @@ def run_config():
                     'pull_data_dictionaries': True
                 }
             },
+            'sample_extract_records': {
+                'config': {
+                    'api_token': 'fake_token',
+                    'end_time': 'fake_time',
+                    'pull_data_dictionaries': True
+                }
+            },
+            'eols_extract_records': {
+                'config': {
+                    'api_token': 'fake_token',
+                    'end_time': 'fake_time',
+                    'pull_data_dictionaries': True
+                }
+            },
             'write_outfiles': {
                 'config': {
                     'working_dir': 'fake_dir'

--- a/orchestration/dev_refresh.yaml
+++ b/orchestration/dev_refresh.yaml
@@ -21,5 +21,15 @@ solids:
       api_token: ""
       pull_data_dictionaries: false
       end_time: "2020-03-30T23:59:59-05:00"
+    sample_extract_records:
+      config:
+        api_token: ""
+        pull_data_dictionaries: false
+        end_time: "2020-03-30T23:59:59-05:00"
+    eols_extract_records:
+      config:
+        api_token: ""
+        pull_data_dictionaries: false
+        end_time: "2020-03-30T23:59:59-05:00"
 
 


### PR DESCRIPTION
## Why
We have added sample and EOLS extraction and transformation. We need to implement them when running a refresh
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1829)

## This PR
Adds Sample/EOLS extract/transform solids
Updates pipeline to utilize the solids
## Checklist
- [ ] Documentation has been updated as needed.
