### PR TITLE
Refactor TruncatedDecimalError as a warning

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationLog.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/hles/HLESurveyTransformationLog.scala
@@ -29,8 +29,22 @@ class HLESurveyTransformationError(msg: String) extends HLESurveyTransformationL
     )
 }
 
+class HLESurveyTransformationWarning(msg: String) extends HLESurveyTransformationLog {
+
+  def log(implicit logger: Logger): Unit = {
+    logger.error(jsonMsg.toString())
+    counter("hles", "hles_transformation_warning").inc()
+  }
+
+  val jsonMsg: Obj = ujson
+    .Obj(
+      "errorType" -> ujson.Str(this.getClass.getSimpleName),
+      "message" -> ujson.Str(msg)
+    )
+}
+
 // case classes for all the different actual warnings and errors we want to raise during the workflow
 case class MissingOwnerIdError(msg: String) extends HLESurveyTransformationError(msg)
-case class TruncatedDecimalError(msg: String) extends HLESurveyTransformationError(msg)
+case class TruncatedDecimalError(msg: String) extends HLESurveyTransformationWarning(msg)
 case class MissingCalcFieldError(msg: String) extends HLESurveyTransformationError(msg)
 case class InvalidArmMonthError(msg: String) extends HLESurveyTransformationError(msg)


### PR DESCRIPTION
## Why

The TruncatedDecimalError throws an Exception during PostProcess, which causes a full refresh to fail.
We should create a warning class that the decimal error can inherit from and make sure that that warning class is not included in the main errorCounter since that is what trips the HLESurveyTransformationWarning in PostProcess.scala

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1849)

## This PR

- Created a new warning class for the HLES Transformation pipeline which the TruncatedDecimalError will now extend.
- This new warning type will count hles_transformation_warning errors within the hles namespace instead of the main errCount.

## Checklist
- [ ] Documentation has been updated as needed.
