### PR TITLE
Rename EOLS Variable

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/IllnessTransformations.scala
@@ -62,7 +62,7 @@ object IllnessTransformations {
         if (otherCancerCondition.contains(true))
           rawRecord.getOptionalStripped("eol_cancer_a_specify")
         else None,
-      eolIlllnessCancerNameKnown = cancerNameKnown,
+      eolIllnessCancerNameKnown = cancerNameKnown,
       eolIllnessCancerNameDescription =
         if (cancerNameKnown.contains(1L))
           rawRecord.getOptionalStripped("eol_cancer_b_specify")

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/IllnessTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/IllnessTransformationsSpec.scala
@@ -32,7 +32,7 @@ class IllnessTransformationsSpec extends AnyFlatSpec with Matchers with OptionVa
     cancerMapped.eolIllnessCancerVenereal shouldBe Some(true)
     cancerMapped.eolIllnessCancerOther shouldBe Some(true)
     cancerMapped.eolIllnessCancerOtherDescription shouldBe Some("Some other type of cancer")
-    cancerMapped.eolIlllnessCancerNameKnown shouldBe Some(1L)
+    cancerMapped.eolIllnessCancerNameKnown shouldBe Some(1L)
     cancerMapped.eolIllnessCancerNameDescription shouldBe Some("New type of cancer")
     cancerMapped.eolIllnessAwarenessTimeframe shouldBe Some(0L)
     cancerMapped.eolIllnessTreatment shouldBe Some(7L)

--- a/orchestration/dap_orchestration/config/resources/dataflow_beam_runner/prod.yaml
+++ b/orchestration/dap_orchestration/config/resources/dataflow_beam_runner/prod.yaml
@@ -1,1 +1,1 @@
-google_project: broad-dsp-monster-dap-prod
+google_project: exemplary-proxy-308717

--- a/schema/src/main/jade-fragments/eols_illness.fragment.json
+++ b/schema/src/main/jade-fragments/eols_illness.fragment.json
@@ -162,7 +162,7 @@
             "datatype": "string"
         },
         {
-            "name": "eol_illlness_cancer_name_known",
+            "name": "eol_illness_cancer_name_known",
             "datatype": "integer"
         },
         {


### PR DESCRIPTION
## Why
Typo in the proto schema DAP provided us:
eol_illlness_cancer_name_known > eol_illness_cancer_name_known
[Relevant ticket](https://broadinstitute.atlassian.net/browse/dspdc-1837)

## This PR
Renamed a Terra variable in the json schema, transformation code, and unit test.

## Checklist
- [ ] Documentation has been updated as needed.
