### PR TITLE
Fix Environment Extraction Pipeline

### DIFF
--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
@@ -26,7 +26,7 @@ class OkWrapper extends HttpWrapper {
         override def log(s: String): Unit = {
           logger.info(s)
         }
-      }).setLevel(Level.BASIC))
+      }).setLevel(Level.BODY))
       .build()
 
   def makeRequest(request: Request): Future[Msg] = {

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
@@ -26,7 +26,7 @@ class OkWrapper extends HttpWrapper {
         override def log(s: String): Unit = {
           logger.info(s)
         }
-      }).setLevel(Level.BODY))
+      }).setLevel(Level.HEADERS))
       .build()
 
   def makeRequest(request: Request): Future[Msg] = {

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
@@ -4,7 +4,9 @@ import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
 import org.broadinstitute.monster.dap.common._
 
 import java.time.{OffsetDateTime, ZoneOffset}
-import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoField
+import java.time.format.DateTimeFormatterBuilder
+import collection.JavaConverters._
 
 // Ignore IntelliJ, this is used to make the implicit parser compile.
 import Args._
@@ -13,9 +15,9 @@ class EnvironmentExtractionFailException() extends Exception
 
 object EnvironmentExtractionPipeline extends ScioApp[Args] {
 
-  val formatter = DateTimeFormatter.ofPattern("MMMyyyy")
-  val formatter_month = DateTimeFormatter.ofPattern("MMMM")
-  val formatter_year = DateTimeFormatter.ofPattern("yyyy")
+  //val formatter = DateTimeFormatter.ofPattern("MMMyyyy")
+  //val formatter_month = DateTimeFormatter.ofPattern("MMMM")
+  //val formatter_year = DateTimeFormatter.ofPattern("yyyy")
 
   val EnvironmentEpoch = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-5))
 
@@ -44,20 +46,34 @@ object EnvironmentExtractionPipeline extends ScioApp[Args] {
 
   val subdir = "environment"
 
+  // Utilizing the custom date formatter since June, July, and Sept have non standard abbreviations
+  val monthMap: java.util.Map[java.lang.Long, String] = Map(
+    Long.box(1L) -> "Jan",
+    Long.box(2L) -> "Feb",
+    Long.box(3L) -> "Mar",
+    Long.box(4L) -> "Apr",
+    Long.box(5L) -> "May",
+    Long.box(6L) -> "June",
+    Long.box(7L) -> "July",
+    Long.box(8L) -> "Aug",
+    Long.box(9L) -> "Sept",
+    Long.box(10L) -> "Oct",
+    Long.box(11L) -> "Nov",
+    Long.box(12L) -> "Dec"
+  ).asJava
+
+  val formatter = new DateTimeFormatterBuilder()
+    .appendText(ChronoField.MONTH_OF_YEAR, monthMap)
+    .appendPattern("yyyy")
+    .toFormatter()
+
   // get list of individual dates, then get the set of years and return a list of distinct monthYears
   def getMonthYearList(start: OffsetDateTime, end: OffsetDateTime): List[String] = {
     if (start.isAfter(end)) throw new EnvironmentExtractionFailException
     val dateList =
       (Iterator.iterate(start)(_ plusDays 1) takeWhile (_ isBefore end.plusDays(1))).toList
     dateList
-      .map(date =>
-        // event names for June, July, and Sept have 4 alpha characters before the year
-        if (List(6, 7, 9).contains(date.getMonthValue)) {
-          date.format(formatter_month).toLowerCase.slice(0, 4) + date
-            .format(formatter_year)
-            .toLowerCase
-        } else date.format(formatter).toLowerCase
-      )
+      .map(date => date.format(formatter).toLowerCase)
       .distinct
   }
 

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
@@ -15,10 +15,6 @@ class EnvironmentExtractionFailException() extends Exception
 
 object EnvironmentExtractionPipeline extends ScioApp[Args] {
 
-  //val formatter = DateTimeFormatter.ofPattern("MMMyyyy")
-  //val formatter_month = DateTimeFormatter.ofPattern("MMMM")
-  //val formatter_year = DateTimeFormatter.ofPattern("yyyy")
-
   val EnvironmentEpoch = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-5))
 
   val forms = List(

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipeline.scala
@@ -14,7 +14,8 @@ class EnvironmentExtractionFailException() extends Exception
 object EnvironmentExtractionPipeline extends ScioApp[Args] {
 
   val formatter = DateTimeFormatter.ofPattern("MMMyyyy")
-  val formatterAlt = DateTimeFormatter.ofPattern("MMMMyyyy")
+  val formatter_month = DateTimeFormatter.ofPattern("MMMM")
+  val formatter_year = DateTimeFormatter.ofPattern("yyyy")
 
   val EnvironmentEpoch = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-5))
 
@@ -51,8 +52,10 @@ object EnvironmentExtractionPipeline extends ScioApp[Args] {
     dateList
       .map(date =>
         // event names for June, July, and Sept have 4 alpha characters before the year
-        if (List(6,7,9).contains(date.getMonthValue) ) {
-          date.format(formatterAlt).toLowerCase.distinct
+        if (List(6, 7, 9).contains(date.getMonthValue)) {
+          date.format(formatter_month).toLowerCase.slice(0, 4) + date
+            .format(formatter_year)
+            .toLowerCase
         } else date.format(formatter).toLowerCase
       )
       .distinct

--- a/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipelineSpec.scala
+++ b/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/environment/EnvironmentExtractionPipelineSpec.scala
@@ -15,30 +15,30 @@ class EnvironmentExtractionPipelineSpec extends AnyFlatSpec with Matchers {
       EnvironmentExtractionPipeline.extractionArmsGenerator(Some(startTime), Some(endTime))
 
     envArms shouldBe List(
-      "annual_feb2020_arm_1",
-      "annual_feb2020_secondary_arm_1",
-      "annual_mar2020_arm_1",
-      "annual_mar2020_secondary_arm_1",
-      "annual_apr2020_arm_1",
-      "annual_apr2020_secondary_arm_1",
-      "annual_may2020_arm_1",
-      "annual_may2020_secondary_arm_1",
-      "annual_jun2020_arm_1",
-      "annual_jun2020_secondary_arm_1",
-      "annual_jul2020_arm_1",
-      "annual_jul2020_secondary_arm_1",
-      "annual_aug2020_arm_1",
-      "annual_aug2020_secondary_arm_1",
-      "annual_sep2020_arm_1",
-      "annual_sep2020_secondary_arm_1",
-      "annual_oct2020_arm_1",
-      "annual_oct2020_secondary_arm_1",
-      "annual_nov2020_arm_1",
-      "annual_nov2020_secondary_arm_1",
-      "annual_dec2020_arm_1",
-      "annual_dec2020_secondary_arm_1",
-      "annual_jan2021_arm_1",
-      "annual_jan2021_secondary_arm_1"
+      "feb2020_arm_1",
+      "feb2020_secondary_arm_1",
+      "mar2020_arm_1",
+      "mar2020_secondary_arm_1",
+      "apr2020_arm_1",
+      "apr2020_secondary_arm_1",
+      "may2020_arm_1",
+      "may2020_secondary_arm_1",
+      "june2020_arm_1",
+      "june2020_secondary_arm_1",
+      "july2020_arm_1",
+      "july2020_secondary_arm_1",
+      "aug2020_arm_1",
+      "aug2020_secondary_arm_1",
+      "sept2020_arm_1",
+      "sept2020_secondary_arm_1",
+      "oct2020_arm_1",
+      "oct2020_secondary_arm_1",
+      "nov2020_arm_1",
+      "nov2020_secondary_arm_1",
+      "dec2020_arm_1",
+      "dec2020_secondary_arm_1",
+      "jan2021_arm_1",
+      "jan2021_secondary_arm_1"
     )
   }
 
@@ -49,12 +49,12 @@ class EnvironmentExtractionPipelineSpec extends AnyFlatSpec with Matchers {
     val envArms = EnvironmentExtractionPipeline.extractionArmsGenerator(None, Some(endTime))
 
     envArms shouldBe List(
-      "annual_jan2020_arm_1",
-      "annual_jan2020_secondary_arm_1",
-      "annual_feb2020_arm_1",
-      "annual_feb2020_secondary_arm_1",
-      "annual_mar2020_arm_1",
-      "annual_mar2020_secondary_arm_1"
+      "jan2020_arm_1",
+      "jan2020_secondary_arm_1",
+      "feb2020_arm_1",
+      "feb2020_secondary_arm_1",
+      "mar2020_arm_1",
+      "mar2020_secondary_arm_1"
     )
   }
 
@@ -68,10 +68,10 @@ class EnvironmentExtractionPipelineSpec extends AnyFlatSpec with Matchers {
       EnvironmentExtractionPipeline.extractionArmsGenerator(Some(startTime), Some(endTime))
 
     envArms shouldBe List(
-      "annual_mar2020_arm_1",
-      "annual_mar2020_secondary_arm_1",
-      "annual_apr2020_arm_1",
-      "annual_apr2020_secondary_arm_1"
+      "mar2020_arm_1",
+      "mar2020_secondary_arm_1",
+      "apr2020_arm_1",
+      "apr2020_secondary_arm_1"
     )
   }
 

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/eols/DeathTransformations.scala
@@ -23,7 +23,7 @@ object DeathTransformations {
       eolDeathWitnessWhoBoarder = deathWitness.map(_.contains("5")),
       eolDeathWitnessWhoOther = deathWitnessOther,
       eolDeathWitnessWhoOtherDescription =
-        if (deathWitness.contains(true))
+        if (deathWitnessOther.contains(true))
           rawRecord.getOptionalStripped("eol_who_present_specify")
         else None
     )

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/DeathTransformationsSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/eols/DeathTransformationsSpec.scala
@@ -26,4 +26,20 @@ class DeathTransformationsSpec extends AnyFlatSpec with Matchers with OptionValu
     deathMapped.eolDeathWitnessWhoYou.value shouldBe true
     deathMapped.eolDeathWitnessWhoFamily.value shouldBe true
   }
+
+  it should "map death transformations for others present at death" in {
+    val DeathTransform = Map(
+      "eol_anyone_present" -> Array("1"),
+      "eol_who_present" -> Array("98"),
+      "eol_who_present_specify" -> Array("Someone else")
+    )
+
+    val deathMapped = DeathTransformations.mapDeathTransformations(
+      RawRecord(1, DeathTransform)
+    )
+
+    deathMapped.eolDeathWitness.value shouldBe 1L
+    deathMapped.eolDeathWitnessWhoOther.value shouldBe true
+    deathMapped.eolDeathWitnessWhoOtherDescription.value shouldBe "Someone else"
+  }
 }


### PR DESCRIPTION
## Why
The environment pipeline is not extracting any records due to some bad filter logic.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/dspdc-1874)

## This PR
Refactored the logic to generate arms for the environment pipeline.
There is no "annual_" prefix for environment events and also months June, July, and September have a slightly different date format.

## Checklist
- [ ] Documentation has been updated as needed.
