### PR TITLE
Automate DAP sample TSV weekly

### DIFF
--- a/hack/convert-output-to-tsv.py
+++ b/hack/convert-output-to-tsv.py
@@ -9,6 +9,7 @@ import os
 from dataclasses import dataclass, field
 
 from gcsfs.core import GCSFileSystem
+from gcloud import storage
 
 
 def remove_prefix(text, prefix):
@@ -18,11 +19,14 @@ def remove_prefix(text, prefix):
     return text
 
 
-parser = argparse.ArgumentParser(description="Convert the records in a specified bucket prefix to a Terra-compatible TSV")
+parser = argparse.ArgumentParser(
+    description="Convert the records in a specified bucket prefix to a Terra-compatible TSV")
 parser.add_argument('input_dir', metavar='I', help='The bucket prefix to read records from')
 parser.add_argument('output_dir', metavar='O', help='The local directory to write the resulting TSVs to')
-parser.add_argument('table', nargs='*', help="One or more tables to process into TSVs. Processes all tables if none specified.")
-parser.add_argument('--firecloud', action='store_true', help="Use logic to generate primary keys for Terra upload via Firecloud")
+parser.add_argument('table', nargs='*',
+                    help="One or more tables to process into TSVs. Processes all tables if none specified.")
+parser.add_argument('--firecloud', action='store_true',
+                    help="Use logic to generate primary keys for Terra upload via Firecloud")
 parser.add_argument('--debug', action='store_true', help="Write additional logs for debugging")
 args = parser.parse_args()
 
@@ -33,8 +37,8 @@ log = logging.getLogger(__name__)
 
 TERRA_COLUMN_LIMIT = 1000
 
-table_names = args.table or ['cslb', 'hles_cancer_condition', 'hles_dog', 'hles_health_condition', 'hles_owner',
-                             'environment', 'sample', 'eols']
+# table_names = args.table or ['cslb', 'hles_cancer_condition', 'hles_dog', 'hles_health_condition', 'hles_owner',
+#                              'environment', 'sample', 'eols']
 PRIMARY_KEY_PREFIX = 'entity'
 
 gcs = GCSFileSystem()
@@ -49,7 +53,8 @@ class PrimaryKeyGenerator:
     # this will calculate pk_name during init
     def __post_init__(self):
         # most tables should have "dog_id" as a key
-        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb", "eols"}:
+        if self.table_name in {"hles_dog", "hles_cancer_condition", "hles_health_condition", "environment", "cslb",
+                               "eols"}:
             self.pk_name = 'dog_id'
         # owner table is linked to hles_dog via "owner_id"
         elif self.table_name == 'hles_owner':
@@ -79,7 +84,8 @@ class PrimaryKeyGenerator:
                 congenital_flag = int(congenital_flag)
             except TypeError:
                 log.warning(f"Error, 'hs_condition_is_congenital' is not populated in {self.table_name}")
-            return '-'.join([str(component) for component in [row.get('dog_id'), row.get('hs_condition'), congenital_flag]])
+            return '-'.join(
+                [str(component) for component in [row.get('dog_id'), row.get('hs_condition'), congenital_flag]])
         # environment: read + copy dog_id and address fields to concatenate for generated uuid
         elif self.table_name == "environment":
             primary_key_fields = ['dog_id', 'address_1_or_2', 'address_month', 'address_year']
@@ -88,104 +94,116 @@ class PrimaryKeyGenerator:
         else:
             return row.pop(self.pk_name)
 
-# Process the known (hardcoded) tables
-for table_name in table_names:
-    log.info(f"PROCESSING {table_name}")
-    primary_key_gen = PrimaryKeyGenerator(table_name, args.firecloud)
-    # set to hold all columns for this table, list to hold all the rows
-    column_set = set()
-    row_list = []
-    # generated PK column headers for Firecloud compatibility
-    entity_name = primary_key_gen.generate_entity_name()
 
-    # read json data
-    for path in gcs.ls(os.path.join(args.input_dir, table_name)):
-        log.info(f"...Opening {path}")
+def process_tables(table_names: list[str]):
+    for table_name in table_names:
+        log.info(f"PROCESSING {table_name}")
+        primary_key_gen = PrimaryKeyGenerator(table_name, args.firecloud)
+        # set to hold all columns for this table, list to hold all the rows
+        column_set = set()
+        row_list = []
+        # generated PK column headers for Firecloud compatibility
+        entity_name = primary_key_gen.generate_entity_name()
 
-        with gcs.open(path, 'r') as json_file:
-            print(path, json_file)
-            for line in json_file:
-                row = json.loads(line)
+        # read json data
+        for path in gcs.ls(os.path.join(args.input_dir, table_name)):
+            log.info(f"...Opening {path}")
 
-                if not row:
-                    raise RuntimeError(f'Encountered invalid JSON "{line}", aborting.')
+            with gcs.open(path, 'r') as json_file:
+                print(path, json_file)
+                for line in json_file:
+                    row = json.loads(line)
 
-                row[entity_name] = primary_key_gen.generate_primary_key(row)
+                    if not row:
+                        raise RuntimeError(f'Encountered invalid JSON "{line}", aborting.')
 
-                column_set.update(row.keys())
-                row_list.append(row)
+                    row[entity_name] = primary_key_gen.generate_primary_key(row)
 
-    # make sure pk is the first column (Firecloud req.)
-    # pop out the PK, will be splitting this set out later
-    column_set.discard(entity_name)
-    # logic to move the actual PK columns to beginning of file (where we have generated one)
-    if args.firecloud and table_name in {"hles_health_condition", "environment"}:
-        column_set.discard(primary_key_gen.pk_name)
-        sorted_column_set = [entity_name] + [primary_key_gen.pk_name] + sorted(list(column_set))
-    else:
-        sorted_column_set = [entity_name] + sorted(list(column_set))
+                    column_set.update(row.keys())
+                    row_list.append(row)
 
-    # provide some stats
-    col_count = len(sorted_column_set)
-    log.info(f"...{table_name} contains {len(row_list)} rows and {col_count} columns")
-    # output to tsv
-    # 512 column max limit per request (upload to workspace)
-    if col_count > TERRA_COLUMN_LIMIT:
-        # calculate chunks needed - each table requires the PK
-        total_col_count = ceil(col_count/TERRA_COLUMN_LIMIT)+col_count-1
-        chunks = ceil(total_col_count/TERRA_COLUMN_LIMIT)
-        log.info(f"...Splitting {table_name} into {chunks} files")
-        log.info(f"...{len(column_set)} cols in init list")
-        # FOR EACH SPLIT
-        for chunk in range(1, chunks+1):
-            # Incremented outfile name
-            output_location = os.path.join(args.output_dir, f'{table_name}_{chunk}.tsv')
-            log.info(f"...Processing Split #{chunk} to {output_location}")
-            split_column_set = set()
-            # add 511 columns
-            for _ in range(TERRA_COLUMN_LIMIT - 1):
-                try:
-                    col = column_set.pop()
-                except KeyError:
-                    # KeyError is raised when we're out of columns to pop
-                    break
-                split_column_set.add(col)
-                log.debug(f"......adding {col} to split_column_set ({len(split_column_set)}) ...{len(column_set)} columns left")
-            split_column_list = [entity_name] + sorted(list(split_column_set))
-            log.info(f"......Split #{chunk} now contains {len(split_column_list)} columns")
-            log.debug(f"cols in split: {len(split_column_list)}")
-            log.debug(f"cols left to split: {len(column_set)}")
+        # make sure pk is the first column (Firecloud req.)
+        # pop out the PK, will be splitting this set out later
+        column_set.discard(entity_name)
+        # logic to move the actual PK columns to beginning of file (where we have generated one)
+        if args.firecloud and table_name in {"hles_health_condition", "environment"}:
+            column_set.discard(primary_key_gen.pk_name)
+            sorted_column_set = [entity_name] + [primary_key_gen.pk_name] + sorted(list(column_set))
+        else:
+            sorted_column_set = [entity_name] + sorted(list(column_set))
 
-            def clean_up_string_whitespace(val):
-                try:
-                    return val.replace('\r\n', ' ').strip()
-                except AttributeError:
-                    return val
+        # provide some stats
+        col_count = len(sorted_column_set)
+        log.info(f"...{table_name} contains {len(row_list)} rows and {col_count} columns")
+        # output to tsv
+        # 512 column max limit per request (upload to workspace)
+        if col_count > TERRA_COLUMN_LIMIT:
+            # calculate chunks needed - each table requires the PK
+            total_col_count = ceil(col_count / TERRA_COLUMN_LIMIT) + col_count - 1
+            chunks = ceil(total_col_count / TERRA_COLUMN_LIMIT)
+            log.info(f"...Splitting {table_name} into {chunks} files")
+            log.info(f"...{len(column_set)} cols in init list")
+            # FOR EACH SPLIT
+            for chunk in range(1, chunks + 1):
+                # Incremented outfile name
+                output_location = os.path.join(args.output_dir, f'{table_name}_{chunk}.tsv')
+                log.info(f"...Processing Split #{chunk} to {output_location}")
+                split_column_set = set()
+                # add 511 columns
+                for _ in range(TERRA_COLUMN_LIMIT - 1):
+                    try:
+                        col = column_set.pop()
+                    except KeyError:
+                        # KeyError is raised when we're out of columns to pop
+                        break
+                    split_column_set.add(col)
+                    log.debug(
+                        f"......adding {col} to split_column_set ({len(split_column_set)}) ...{len(column_set)} columns left")
+                split_column_list = [entity_name] + sorted(list(split_column_set))
+                log.info(f"......Split #{chunk} now contains {len(split_column_list)} columns")
+                log.debug(f"cols in split: {len(split_column_list)}")
+                log.debug(f"cols left to split: {len(column_set)}")
 
-            # iterate through every row slicing out the values for the columns in this split
-            split_row_dict_list = [
-                {
-                    col: clean_up_string_whitespace(row[col])
-                    for col in split_column_list
-                    if col in row
-                }
-                for row in row_list
-            ]
+                def clean_up_string_whitespace(val):
+                    try:
+                        return val.replace('\r\n', ' ').strip()
+                    except AttributeError:
+                        return val
 
-            # output to tsv
+                # iterate through every row slicing out the values for the columns in this split
+                split_row_dict_list = [
+                    {
+                        col: clean_up_string_whitespace(row[col])
+                        for col in split_column_list
+                        if col in row
+                    }
+                    for row in row_list
+                ]
+
+                # output to tsv
+                with open(output_location, 'w') as output_file:
+                    dw = csv.DictWriter(output_file, split_column_list, delimiter='\t')
+                    dw.writeheader()
+                    dw.writerows(split_row_dict_list)
+                log.info(f"......{table_name} Split #{chunk} was successfully written to {output_location}")
+        else:
+            # this branch is executed for any tables with 512 cols or less
+            log.info(f"...No need to split files for {table_name}")
+            output_location = os.path.join(args.output_dir, f'{table_name}.tsv')
+            log.info(f"...Writing {table_name} to {output_location}")
             with open(output_location, 'w') as output_file:
-                dw = csv.DictWriter(output_file, split_column_list, delimiter='\t')
+                dw = csv.DictWriter(output_file, sorted_column_set, delimiter='\t')
                 dw.writeheader()
-                dw.writerows(split_row_dict_list)
+                dw.writerows(row_list)
+                upload_sample_tsv(output_file)
+            log.info(f"...{table_name} was successfully written to {output_location}")
 
-            log.info(f"......{table_name} Split #{chunk} was successfully written to {output_location}")
-    else:
-        # this branch is executed for any tables with 512 cols or less
-        log.info(f"...No need to split files for {table_name}")
-        output_location = os.path.join(args.output_dir, f'{table_name}.tsv')
-        log.info(f"...Writing {table_name} to {output_location}")
-        with open(output_location, 'w') as output_file:
-            dw = csv.DictWriter(output_file, sorted_column_set, delimiter='\t')
-            dw.writeheader()
-            dw.writerows(row_list)
-        log.info(f"...{table_name} was successfully written to {output_location}")
+
+def upload_sample_tsv(output_file):
+    client = storage.Client()
+    bucket = client.get
+    blob = bucket.blob("gs://broad-dsp-monster-dap-dev-storage/weekly_refresh/eric-test")
+    blob.upload_from_filename(output_file)
+
+if __name__ == "__main__":
+    process_tables(table_names=args.table)

--- a/orchestration/dap_orchestration/resources.py
+++ b/orchestration/dap_orchestration/resources.py
@@ -36,12 +36,13 @@ def test_refresh_directory(init_context: InitResourceContext) -> str:
 
 
 class OutfilesWriter:
-    def run(self, working_dir: str, refresh_dir: str) -> None:
+    def run(self, working_dir: str, refresh_dir: str, list_tables: list[str]) -> None:
         outfile_path = f'{working_dir}/tsv_output'
         if not os.path.isdir(outfile_path):
             os.mkdir(outfile_path)
         subprocess.run(
-            ["python", "hack/convert-output-to-tsv.py", f"{refresh_dir}/transform", outfile_path, "--debug"],
+            ["python", "hack/convert-output-to-tsv.py", f"{refresh_dir}/transform", outfile_path, "--debug",
+             "--table", list_tables],
             check=True,
             cwd=working_dir
         )
@@ -53,7 +54,7 @@ def outfiles_writer(init_context: InitResourceContext) -> OutfilesWriter:
 
 
 class TestOutfilesWriter:
-    def run(self, working_dir: str, refresh_dir: str) -> None:
+    def run(self, working_dir: str, refresh_dir: str, table_names: list[str]) -> None:
         pass
 
 

--- a/orchestration/dap_orchestration/tests/test_pipelines.py
+++ b/orchestration/dap_orchestration/tests/test_pipelines.py
@@ -1,7 +1,8 @@
-from dagster import execute_pipeline
+from dagster import execute_pipeline, validate_run_config
+from datetime import datetime
 import pytest
 
-from dap_orchestration.pipelines import refresh_data_all
+from dap_orchestration.pipelines import refresh_data_all, refresh_sample_data, weekly_sample_refresh
 
 
 @pytest.fixture
@@ -61,6 +62,43 @@ def run_config():
     }
 
 
+@pytest.fixture
+def sample_run_config():
+    return {
+        'resources': {
+            'refresh_directory': {
+                'config': {
+                    'refresh_directory': 'fake_dir'
+                }
+            },
+            'api_token': {
+                'config': {
+                    'base_api_token': 'fake_api_token1',
+                    'env_api_token': 'fake_api_token1',
+                }
+            }
+        },
+        'solids': {
+            'sample_extract_records': {
+                'config': {
+                    'end_time': 'fake_time',
+                    'pull_data_dictionaries': True
+                }
+            },
+            'write_outfiles': {
+                'config': {
+                    'working_dir': 'fake_dir'
+                }
+            }
+        }
+    }
+
+
 def test_pipeline(run_config):
     result = execute_pipeline(refresh_data_all, mode="test", run_config=run_config)
+    assert result.success, "Pipeline run should be successful"
+
+
+def test_sample_refresh_pipeline(sample_run_config):
+    result = execute_pipeline(refresh_sample_data, mode="test", run_config=sample_run_config)
     assert result.success, "Pipeline run should be successful"

--- a/orchestration/dap_orchestration/tests/test_solids.py
+++ b/orchestration/dap_orchestration/tests/test_solids.py
@@ -151,7 +151,7 @@ def test_write_outfiles(base_solid_config, mode):
         dap_orchestration.solids.write_outfiles,
         mode_def=mode,
         run_config=dataflow_config,
-        input_values={"fan_in_results": []}
+        input_values={"list_tables": []}
     )
 
     assert result.success

--- a/orchestration/repositories.py
+++ b/orchestration/repositories.py
@@ -1,8 +1,10 @@
+from dap_orchestration.pipelines import weekly_sample_refresh
+
 from dagster import PipelineDefinition, repository
 
-from dap_orchestration.pipelines import refresh_data_all
+from dap_orchestration.pipelines import refresh_data_all, refresh_sample_data
 
 
 @repository
 def repositories() -> list[PipelineDefinition]:
-    return [refresh_data_all]
+    return [refresh_data_all, refresh_sample_data, weekly_sample_refresh]


### PR DESCRIPTION
## Why

- We want to automate a full refresh for sample only
- This PR is a draft PR because running the sample only pipeline seems to produce an empty TSV (This may be the case prior to this PR). Work may be required to investigate this issue

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1867)

## This PR

- Creates a pipeline to only run sample (SampleExtraction, SampleTransformation, TSV output, upload to Google bucket)
- Updates the outfilesWriter to handle running specific tables (list_tables)
- Create weekly partition for Monday, Midnight
- Update solids for all extraction/transformation to return their survey type as a string
- Create test for sample only pipeline

## Checklist
- [ ] Documentation has been updated as needed.
