### PR TITLE
Updating Samples CRON Schedule

### DIFF
--- a/orchestration/dap_orchestration/repositories/prod_repositories.py
+++ b/orchestration/dap_orchestration/repositories/prod_repositories.py
@@ -7,7 +7,7 @@ from datetime import datetime, time
 
 
 @schedule(
-    cron_schedule="30 15 * * 2",
+    cron_schedule="00 04 * * 1",
     pipeline_name="refresh_data_all",
     execution_timezone="US/Eastern",
     solid_selection=["sample_extract_records*"],


### PR DESCRIPTION
## Why
We should kick off the sample pipeline early Monday morning so it has time to complete successfully and be reviewed and delivered on Monday morning.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/dspdc-1867)

## This PR
updating weekly schedule to run at 4AM mondays

## Checklist
- [ ] Documentation has been updated as needed.
