### PR TITLE
De-dupe record IDs

### DIFF
--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/ExtractionPipelineBuilder.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/ExtractionPipelineBuilder.scala
@@ -15,7 +15,6 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 object ExtractionPipelineBuilder {
-
   val MaxConcurrentRequests = 4
 }
 

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/cslb/CslbExtractionPipeline.scala
@@ -69,7 +69,7 @@ object CslbExtractionPipeline extends ScioApp[Args] {
       extractionArmsGenerator,
       fieldList,
       subdir,
-      100,
+      1000,
       RedCapClient.apply(_: List[String], wrapper)
     )
 

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/hles/HLESExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/hles/HLESExtractionPipeline.scala
@@ -63,7 +63,7 @@ object HLESExtractionPipeline extends ScioApp[Args] {
       (_, _) => List(arm),
       fieldList,
       subdir,
-      100,
+      1000,
       RedCapClient.apply(_: List[String], wrapper)
     )
 


### PR DESCRIPTION
## Why

It's possible for us to get a record ID back twice when we request records across > 1 survey arm, leading to redundant work downstream.

## This PR
* Applies a distinct operator to the extracted IDs and fixes up tests to reflect the now non-deterministic ordering of the output

## Checklist
- [ ] Documentation has been updated as needed.
