### PR TITLE
Clear dataflow output dirs prior to execution to avoid duplicate data

### DIFF
--- a/orchestration/dap_orchestration/solids.py
+++ b/orchestration/dap_orchestration/solids.py
@@ -391,6 +391,9 @@ def clear_dir(output_prefix: str, gcs: Client) -> int:
         # todo support local deletions
         return 0
 
+    if output_prefix.endswith("/"):
+        raise Failure("Output dir must not end with '/'")
+
     bucket_with_prefix = parse_gs_path(output_prefix)
     blobs = gcs.list_blobs(bucket_with_prefix.bucket, prefix=f"{bucket_with_prefix.prefix}/")
     deletions_count = 0


### PR DESCRIPTION
## Why

If we don't clear dataflow output dirs prior to running again (say, for the same weekly refresh on retry), we'll end up with duplicate data.

## This PR
* Adds code to delete the data in dataflow output directories

## Checklist
- [ ] Documentation has been updated as needed.
