### PR TITLE
Update weekly date refresh to run on Mondays

### DIFF
--- a/orchestration/dap_orchestration/repositories/prod_repositories.py
+++ b/orchestration/dap_orchestration/repositories/prod_repositories.py
@@ -29,9 +29,8 @@ def build_refresh_data_all_job(name: str) -> PipelineDefinition:
     )
 
 
-# TODO run once a week
 @schedule(
-    cron_schedule="0 4 * * *",
+    cron_schedule="0 4 * * 1",
     job=build_refresh_data_all_job("weekly_data_refresh"),
     execution_timezone="US/Eastern"
 )


### PR DESCRIPTION
## Why

The weekly data refresh job was running daily as we debugged it. Now that it's running ok, let's switch it back to running weekly on Mondays.

## This PR
* Updates the cron schedule
## Checklist
- [x] Documentation has been updated as needed.
