### PR TITLE
Change start date for weekly refresh

### DIFF
--- a/orchestration/dap_orchestration/repositories/prod_repositories.py
+++ b/orchestration/dap_orchestration/repositories/prod_repositories.py
@@ -50,31 +50,36 @@ def weekly_data_refresh(context: ScheduleEvaluationContext) -> dict[str, object]
             "sample_extract_records": {
                 "config": {
                     "pull_data_dictionaries": False,
-                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time
+                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time,
+                    "start_time": "2020-01-01T00:00:00-05:00"
                 }
             },
             "cslb_extract_records": {
                 "config": {
                     "pull_data_dictionaries": False,
-                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time
+                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time,
+                    "start_time": "2020-01-01T00:00:00-05:00"
                 }
             },
             "env_extract_records": {
                 "config": {
                     "pull_data_dictionaries": False,
-                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time
+                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time,
+                    "start_time": "2020-01-01T00:00:00-05:00"
                 }
             },
             "eols_extract_records": {
                 "config": {
                     "pull_data_dictionaries": False,
-                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time
+                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time,
+                    "start_time": "2020-01-01T00:00:00-05:00"
                 }
             },
             "hles_extract_records": {
                 "config": {
                     "pull_data_dictionaries": False,
-                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time
+                    "end_time": date.strftime("%Y-%m-%dT%H:%M:%S") + offset_time,
+                    "start_time": "2020-01-01T00:00:00-05:00"
                 }
             },
             "write_outfiles_in_terra_format": {


### PR DESCRIPTION
## Why

We should be pulling data from 2020-01-01 through now.

## This PR
* Adds a start_time for the relevant surveys.

## Checklist
- [ ] Documentation has been updated as needed.
