### PR TITLE
[DSPDC-1955] Fix retrying logic, add test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val `dog-aging-hles-extraction` = project
   .settings(
     libraryDependencies += "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
     libraryDependencies += "com.squareup.okhttp3" % "logging-interceptor" % okhttpVersion,
-    libraryDependencies += "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion,
+    libraryDependencies += "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion % Test,
     libraryDependencies += "com.bettercloud" % "vault-java-driver" % vaultDriverVersion % IntegrationTest,
     IntegrationTest / parallelExecution := false
   )

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val `dog-aging-hles-extraction` = project
   .settings(
     libraryDependencies += "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
     libraryDependencies += "com.squareup.okhttp3" % "logging-interceptor" % okhttpVersion,
+    libraryDependencies += "com.squareup.okhttp3" % "mockwebserver" % okhttpVersion,
     libraryDependencies += "com.bettercloud" % "vault-java-driver" % vaultDriverVersion % IntegrationTest,
     IntegrationTest / parallelExecution := false
   )

--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/common/OkWrapper.scala
@@ -71,7 +71,7 @@ class OkWrapper extends HttpWrapper {
         override def onResponse(call: Call, response: Response): Unit = {
           if (!response.isSuccessful) {
             p.failure(
-              new Exception(
+              new IOException(
                 s"Non-successful HTTP error code received [response.code=${response.code()}]"
               )
             )

--- a/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/common/OkWrapperSpec.scala
+++ b/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/common/OkWrapperSpec.scala
@@ -6,6 +6,8 @@ import org.broadinstitute.monster.dap.common.OkWrapper.MAX_RETRIES
 import org.scalatest.flatspec.FixtureAsyncFlatSpec
 import upack.Int64
 
+import java.io.IOException
+
 class OkWrapperSpec extends FixtureAsyncFlatSpec {
 
   behavior of "OkWrapper"
@@ -31,7 +33,7 @@ class OkWrapperSpec extends FixtureAsyncFlatSpec {
       server.enqueue(new MockResponse().setResponseCode(500).setBody("error"))
     }
 
-    recoverToSucceededIf[Exception] {
+    recoverToSucceededIf[IOException] {
       okWrapper.makeRequest(request)
     }
   }

--- a/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/common/OkWrapperSpec.scala
+++ b/dap-etl/extraction/src/test/scala/org/broadinstitute/monster/dap/common/OkWrapperSpec.scala
@@ -1,0 +1,52 @@
+package org.broadinstitute.monster.dap.common
+
+import okhttp3.Request
+import okhttp3.mockwebserver.{MockResponse, MockWebServer}
+import org.broadinstitute.monster.dap.common.OkWrapper.MAX_RETRIES
+import org.scalatest.flatspec.FixtureAsyncFlatSpec
+import upack.Int64
+
+class OkWrapperSpec extends FixtureAsyncFlatSpec {
+
+  behavior of "OkWrapper"
+
+  type FixtureParam = MockWebServer
+
+  override def withFixture(test: OneArgAsyncTest) = {
+    val server = new MockWebServer
+    server.start()
+
+    complete {
+      withFixture(test.toNoArgAsyncTest(server))
+    } lastly {
+      server.shutdown()
+    }
+  }
+
+  it should "fail out after MAX_RETRIES" in { server =>
+    val serverUrl = server.url("/v1/testing")
+    val okWrapper = new OkWrapper
+    val request = new Request.Builder().url(serverUrl).build()
+    (0 to MAX_RETRIES).foreach { _ =>
+      server.enqueue(new MockResponse().setResponseCode(500).setBody("error"))
+    }
+
+    recoverToSucceededIf[Exception] {
+      okWrapper.makeRequest(request)
+    }
+  }
+
+  it should "retry and succeed after a 500 response" in { server =>
+    val serverUrl = server.url("/v1/testing")
+    val okWrapper = new OkWrapper
+    val request = new Request.Builder().url(serverUrl).build()
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("error"))
+    server.enqueue(new MockResponse().setResponseCode(200).setBody("[1]"))
+
+    okWrapper.makeRequest(request).map { result =>
+      assert(result.arr.length == 1)
+      assert(result.arr(0) == Int64(1))
+    }
+  }
+
+}


### PR DESCRIPTION
## Why

[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1955)
Our retrying logic is busted; it doesn't actually retry but instead fails out immediately with an `IllegalStateException`:
```
java.lang.IllegalStateException: cannot make a new request because the previous response is still open: please call response.close()"
```

## This PR
* Closes the response prior to proceeding with the retry chain in the failure case
* Adds a test around this code (😢 which should have been there in the first place)
* Fixes the promise retry logic to not throw an Exception but rather fail the promise with an exception instane

## Checklist
- [x] Documentation has been updated as needed.
