### PR TITLE
Added a filter on the samples pipeline for k1_tube_serial

### DIFF
--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
@@ -1,18 +1,20 @@
 package org.broadinstitute.monster.dap.sample
 
-import org.broadinstitute.monster.dogaging.jadeschema.table.Sample
 import org.broadinstitute.monster.dap.common.RawRecord
+import org.broadinstitute.monster.dogaging.jadeschema.table.Sample
 
 object SampleTransformations {
 
   def mapSampleData(rawRecord: RawRecord): Option[Sample] = {
-    rawRecord.getOptionalDateTime("k1_rtn_tracking_date") match {
-      case Some(dateCollected) =>
+    val dateCollected = rawRecord.getOptionalDateTime("k1_rtn_tracking_date")
+    val kitId = rawRecord.getOptionalNumber("k1_tube_serial")
+    (dateCollected, kitId) match {
+      case (Some(dateCollected), Some(kitId)) =>
         Some(
           Sample(
             dogId = rawRecord.getRequired("study_id").toLong,
             cohort = rawRecord.getRequired("ce_enroll_stat").toLong,
-            sampleId = rawRecord.getRequired("k1_tube_serial").toLong,
+            sampleId = kitId,
             sampleType = "saliva_DNA_lowcov",
             dateSwabArrivalLaboratory = dateCollected
           )

--- a/dap-etl/transformation/src/test/resources/sample_missing_kit_id.json
+++ b/dap-etl/transformation/src/test/resources/sample_missing_kit_id.json
@@ -14,4 +14,4 @@
 {"record":"12345","redcap_event_name":"baseline_arm_1","field_name":"ss_dog_sleep","value":"1"}
 {"record":"12345","redcap_event_name":"baseline_arm_1","field_name":"ss_timestamp","value":"2021-04-10 9:15"}
 {"record":"12345","redcap_event_name":"baseline_arm_1","field_name":"recruitment_fields_complete","value":"2"}
-{"record":"12345","redcap_event_name":"baseline_arm_1","field_name":"k1_tube_serial","value":"123456789"}
+{"record":"12345","redcap_event_name":"baseline_arm_1","field_name":"k1_rtn_tracking_date","value":"2021-01-19 13:16:00"}

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/SampleTransformationPipelineTest.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/SampleTransformationPipelineTest.scala
@@ -28,4 +28,13 @@ class SampleTransformationPipelineTest extends PipelineSpec with Matchers {
       .output(TextIO("out/sample"))(col => col should beEmpty)
       .run()
   }
+
+  it should "not process a sample record without k1_tube_serial" in {
+    val lines = Source.fromResource("sample_missing_kit_id.json").getLines().toSeq
+    JobTest[SampleTransformationPipeline.type]
+      .args("--inputPrefix=in", "--outputPrefix=out")
+      .input(TextIO("in/records/*.json"), lines)
+      .output(TextIO("out/sample"))(col => col should beEmpty)
+      .run()
+  }
 }

--- a/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/sample/SampleTransformationSpec.scala
+++ b/dap-etl/transformation/src/test/scala/org/broadinstitute/monster/dap/sample/SampleTransformationSpec.scala
@@ -25,7 +25,10 @@ class SampleTransformationSpec extends AnyFlatSpec {
   }
 
   it should "raise when date is invalid" in {
-    val invalidDateRecord = RawRecord(id = 1, Map("k1_rtn_tracking_date" -> Array("2020-142-124")))
+    val invalidDateRecord = RawRecord(
+      id = 1,
+      Map("k1_rtn_tracking_date" -> Array("2020-142-124"), "k1_tube_serial" -> Array("12345"))
+    )
     assertThrows[DateTimeParseException] {
       SampleTransformations.mapSampleData(invalidDateRecord)
     }
@@ -48,8 +51,7 @@ class SampleTransformationSpec extends AnyFlatSpec {
 
   it should "raise when serial number is not provided" in {
     val invalidSerialRecord = RawRecord(id = 1, exampleSampleFields.-("k1_tube_serial"))
-    assertThrows[IllegalStateException] {
-      SampleTransformations.mapSampleData(invalidSerialRecord)
-    }
+    val output = SampleTransformations.mapSampleData(invalidSerialRecord)
+    output shouldBe None
   }
 }


### PR DESCRIPTION
## Why
When DAP has to redo dna kits for participants, they clear out the old swab id but not the swab date. This results in a handful of records that are missing a value for the k1_tube_serial. We were only checking the swab date and still trying to pull the kit id as a required field which has been causing the sample pipeline to error in production.

[Relevant ticket](https://broadinstitute.atlassian.net/browse/<ticket_id>)

## This PR

- Added a filter.
- Updated tests.

## Checklist
- [ ] Documentation has been updated as needed.
