### PR TITLE
Bugfix for samples production pipeline

### DIFF
--- a/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/sample/SampleExtractionPipeline.scala
+++ b/dap-etl/extraction/src/main/scala/org/broadinstitute/monster/dap/sample/SampleExtractionPipeline.scala
@@ -19,14 +19,12 @@ object SampleExtractionPipeline extends ScioApp[Args] {
     "recruitment_fields"
   )
 
-  def extractionFiltersGenerator(args: Args): List[FilterDirective] =
-    args.startTime
-      .map(start =>
-        List(
-          FilterDirective("k1_rtn_tracking_date", FilterOps.>, RedCapClient.redcapFormatDate(start))
-        )
-      )
-      .getOrElse(List()) ++
+  def extractionFiltersGenerator(args: Args): List[FilterDirective] = {
+    val standardDirectives: List[FilterDirective] = List(
+      // DAP Pack filters
+      FilterDirective("st_dap_pack_count", FilterOps.>, "0")
+    )
+    val dateFilters: List[FilterDirective] = {
       args.endTime
         .map(end =>
           List(
@@ -34,6 +32,9 @@ object SampleExtractionPipeline extends ScioApp[Args] {
           )
         )
         .getOrElse(List())
+    }
+    standardDirectives ++ dateFilters
+  }
 
   val subdir = "sample";
   val arm = "baseline_arm_1"

--- a/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
+++ b/dap-etl/transformation/src/main/scala/org/broadinstitute/monster/dap/sample/SampleTransformations.scala
@@ -8,12 +8,13 @@ object SampleTransformations {
   def mapSampleData(rawRecord: RawRecord): Option[Sample] = {
     val dateCollected = rawRecord.getOptionalDateTime("k1_rtn_tracking_date")
     val kitId = rawRecord.getOptionalNumber("k1_tube_serial")
-    (dateCollected, kitId) match {
-      case (Some(dateCollected), Some(kitId)) =>
+    val cohort = rawRecord.getOptionalNumber("ce_enroll_stat")
+    (dateCollected, kitId, cohort) match {
+      case (Some(dateCollected), Some(kitId), Some(cohort)) =>
         Some(
           Sample(
             dogId = rawRecord.getRequired("study_id").toLong,
-            cohort = rawRecord.getRequired("ce_enroll_stat").toLong,
+            cohort = cohort,
             sampleId = kitId,
             sampleType = "saliva_DNA_lowcov",
             dateSwabArrivalLaboratory = dateCollected


### PR DESCRIPTION
## Why
Samples pipeline in production is failing on the following error:
java.lang.IllegalStateException: Record 115647 is missing a value for required field ce_enroll_stat
See most [recent failure job](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-08-15_02_02_26-9442701343806245319;bottomTab=JOB_LOGS;logsSeverity=ERROR;step=?pageState=(%22dfTime%22:(%22s%22:%222022-08-15T09:02:26.976Z%22,%22e%22:%222022-08-15T09:06:35.728Z%22))&project=exemplary-proxy-308717).


## This PR
Updates ce_enroll_stat RedCap field as a non required field.
Updated samples extraction criteria to using dap_pack filters: st_dap_pack_count.

## Checklist
- [ ] Documentation has been updated as needed.
