### PR TITLE
Resolving github actions error

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -30,7 +30,7 @@ jobs:
           JVM_OPTS: -Xmx6144m -Xms6144m -Xss16m
       - name: Publish coverage
         uses: codecov/codecov-action@v1
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@main
         with:
           version: '286.0.0'
           project_id: broad-dsp-monster-dev


### PR DESCRIPTION
## Why
CI on master is failing with the following error on [this job](https://github.com/DataBiosphere/dog-aging-ingest/actions/runs/3098173775/jobs/5015750816):
`Error: Unable to resolve action 'google-github-actions/setup-gcloud@master', unable to find version 'master'`

setup-gcloud now uses "main" instead of "master"

## This PR

## Checklist
- [ ] Documentation has been updated as needed.
